### PR TITLE
Fixes clang error: cast from pointer to smaller type 'unsigned int' l…

### DIFF
--- a/imgui-SFML.cpp
+++ b/imgui-SFML.cpp
@@ -382,7 +382,7 @@ void RenderDrawLists(ImDrawData* draw_data)
             if (pcmd->UserCallback) {
                 pcmd->UserCallback(cmd_list, pcmd);
             } else {
-                glBindTexture(GL_TEXTURE_2D, (GLuint)(unsigned int)pcmd->TextureId);
+                glBindTexture(GL_TEXTURE_2D, (GLuint)(size_t)pcmd->TextureId);
                 glScissor((int)pcmd->ClipRect.x, (int)(fb_height - pcmd->ClipRect.w),
                     (int)(pcmd->ClipRect.z - pcmd->ClipRect.x), (int)(pcmd->ClipRect.w - pcmd->ClipRect.y));
                 glDrawElements(GL_TRIANGLES, (GLsizei)pcmd->ElemCount, GL_UNSIGNED_SHORT, idx_buffer);


### PR DESCRIPTION
…oose information

This PR fixes the following clang++ error:
```sh
[ 16%] Building CXX object CMakeFiles/example.dir/imgui-sfml/imgui-SFML.cpp.o
/Users/eidheim/test/ifud1048/game/imgui-sfml/imgui-SFML.cpp:385:54: error: cast from pointer to smaller type 'unsigned int' loses
      information
                glBindTexture(GL_TEXTURE_2D, (GLuint)(unsigned int)pcmd->TextureId);
                                                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
```