### PR TITLE
Update Image(texture, textureRect...)

### DIFF
--- a/imgui-SFML.cpp
+++ b/imgui-SFML.cpp
@@ -218,7 +218,7 @@ void Image(const sf::Texture& texture, const sf::Vector2f& size,
 void Image(const sf::Texture& texture, const sf::FloatRect& textureRect,
     const sf::Color& tintColor, const sf::Color& borderColor)
 {
-    Image(texture, sf::Vector2f(textureRect.width, textureRect.height), textureRect, tintColor, borderColor);
+    Image(texture, sf::Vector2f(abs(textureRect.width), abs(textureRect.height)), textureRect, tintColor, borderColor);
 }
 
 void Image(const sf::Texture& texture, const sf::Vector2f& size, const sf::FloatRect& textureRect,


### PR DESCRIPTION
Use abs on the size vector before passing it onwards for when given a texture rect with negative width and/or height.

That way, when you want to draw an image with 'flipped' texture coordinates, it won't end up to the left of where it ought to be, or above (ImGui::Image moves the 'cursor' by the size it is given, and draws from where it was to where it now is).