### PR TITLE
Fix issue #44

### DIFF
--- a/imgui-SFML.cpp
+++ b/imgui-SFML.cpp
@@ -141,7 +141,7 @@ namespace SFML
 
 void Init(sf::RenderTarget& target, bool loadDefaultFont)
 {
-	ImGui::CreateContext();
+    ImGui::CreateContext();
     ImGuiIO& io = ImGui::GetIO();
 
     // init keyboard mapping
@@ -317,7 +317,7 @@ void Shutdown()
         s_fontTexture = NULL;
     }
 
-	ImGui::DestroyContext();
+    ImGui::DestroyContext();
 }
 
 void UpdateFontTexture()

--- a/imgui-SFML.cpp
+++ b/imgui-SFML.cpp
@@ -141,6 +141,7 @@ namespace SFML
 
 void Init(sf::RenderTarget& target, bool loadDefaultFont)
 {
+	ImGui::CreateContext();
     ImGuiIO& io = ImGui::GetIO();
 
     // init keyboard mapping
@@ -316,7 +317,7 @@ void Shutdown()
         s_fontTexture = NULL;
     }
 
-    ImGui::Shutdown(); // need to specify namespace here, otherwise ImGui::SFML::Shutdown would be called
+	ImGui::DestroyContext();
 }
 
 void UpdateFontTexture()


### PR DESCRIPTION
In the new version of ImGui the function ImGui::Shutdown() is private. That function is been replaced with ImGui::DestroyContext() and  ImGui::CreateContext() is been called in the ImGui::FSML::Init() function..