### PR TITLE
Add README section about high DPI screens

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,13 @@ ImGui::ImageButton(const sf::Sprite& sprite);
 ImGui::ImageButton(const sf::Texture& texture);
 ```
 
+High DPI screens
+----
+
+As SFML is not currently DPI aware, your window/gui may show at the incorrect scale. This is particularly noticeable on Apple systems with Retina displays.
+
+To fix this on macOS, you can create an app bundle (as opposed to just the exe) then modify the info.plist so that "High Resolution Capable" is set to "NO"
+
 License
 ---
 


### PR DESCRIPTION
Includes a method to fix the issue on macOS. I'm not sure what solution to suggest for high DPI screens on other platforms.

I'll grab a screenshot of the issue for your blog post, but figured it's not worth adding to the README here?
