### PR TITLE
Fix implicit cast warning

### DIFF
--- a/imgui-SFML.cpp
+++ b/imgui-SFML.cpp
@@ -334,7 +334,8 @@ void Update(const sf::Vector2i& mousePos, const sf::Vector2f& displaySize, sf::T
 
     if (s_windowHasFocus) {
         if (io.WantSetMousePos) {
-            sf::Mouse::setPosition(static_cast<sf::Vector2i>(io.MousePos));
+            sf::Vector2i mousePos((int)io.MousePos.x, (int)io.MousePos.y);
+            sf::Mouse::setPosition(mousePos);
         } else {
             io.MousePos = mousePos;
         }

--- a/imgui-SFML.cpp
+++ b/imgui-SFML.cpp
@@ -334,7 +334,7 @@ void Update(const sf::Vector2i& mousePos, const sf::Vector2f& displaySize, sf::T
 
     if (s_windowHasFocus) {
         if (io.WantSetMousePos) {
-            sf::Vector2i mousePos((int)io.MousePos.x, (int)io.MousePos.y);
+            sf::Vector2i mousePos(static_cast<int>(io.MousePos.x), static_cast<int>(io.MousePos.y));
             sf::Mouse::setPosition(mousePos);
         } else {
             io.MousePos = mousePos;


### PR DESCRIPTION
Fixes this warning:

```
imgui.h(132): warning C4244: 'argument': conversion from 'const float' to 'int', possible loss of data
imgui-sfml.cpp(338): note: see reference to function template instantiation 'ImVec2::operator sf::Vector2<int>(void) const<int>' being compiled
```