### PR TITLE
Remove cmake_policy POP

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,10 +44,6 @@ endif()
 # This uses FindImGui.cmake provided in ImGui-SFML repo for now
 find_package(ImGui 1.68 REQUIRED)
 
-if (POLICY CMP0074)
-  cmake_policy(POP)
-endif()
-
 # these headers will be installed alongside ImGui-SFML
 set(IMGUI_PUBLIC_HEADERS
   ${IMGUI_INCLUDE_DIR}/imconfig.h


### PR DESCRIPTION
This piece of code was left in 90d895b8069d35a192b1da664237ce30741299f1, and it causes an error in a fresh build:

```
CMake Error at CMakeLists.txt:48 (cmake_policy):
  cmake_policy POP without matching PUSH
```