### PR TITLE
Conanfile for packaging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,9 @@ set(IMGUI_SFML_CONFIG_INSTALL_DIR "" CACHE PATH "Path where user's config header
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
 
 if (IMGUI_SFML_FIND_SFML)
+        if (NOT BUILD_SHARED_LIBS)
+            set(SFML_STATIC_LIBRARIES CACHE INTERNAL ON)
+        endif()
 	find_package(SFML 2.5 COMPONENTS graphics system window)
 
 	if(NOT SFML_FOUND)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,8 +18,8 @@ option(IMGUI_SFML_FIND_SFML "Use find_package to find SFML" ON)
 # For example, if you have your config in /path/to/dir/with/config/myconfig.h, set the variables as follows:
 #
 #   IMGUI_SFML_USE_DEFAULT_CONFIG = OFF
-#   IMGUI_SFML_USER_CONFIG_DIR = /path/to/dir/with/config
-#   IMGUI_SFML_USER_CONFIG_NAME = "myconfig.h"
+#   IMGUI_SFML_CONFIG_DIR = /path/to/dir/with/config
+#   IMGUI_SFML_CONFIG_NAME = "myconfig.h"
 #
 # If you set IMGUI_SFML_CONFIG_INSTALL_DIR, ImGui-SFML won't install your custom config, because
 # you might want to do it yourself

--- a/conanfile.py
+++ b/conanfile.py
@@ -56,7 +56,7 @@ class ImguiSfmlConan(ConanFile):
         'imgui_revision': 'v1.70'
     }
     exports_sources = [
-        'cmake/FindImGui.cmake'
+        'cmake/FindImGui.cmake',
         'CMakeLists.txt',
         'imconfig-SFML.h',
         'imgui-SFML.cpp',

--- a/conanfile.py
+++ b/conanfile.py
@@ -26,9 +26,9 @@ class ImguiSFML(ConanFile):
       Use 'None' if you want this build to include imconfig.h file,
       otherwise use anything else.
 
-    * imgui_revision: None or String
+    * imgui_revision: String
       Tag or branch of ImGui repository that should be used with
-      ImGui-SFML. 'None' will results in master branch.
+      ImGui-SFML.
     """
 
     name = 'ImGui-SFML'
@@ -67,14 +67,16 @@ class ImguiSFML(ConanFile):
     _imgui_dir = 'imgui'
 
     def source(self):
-        imgui_revision = str(self.options.imgui_revision) if self.options.imgui_revision else 'master'
         git = Git(folder=self._imgui_dir)
-        git.clone('https://github.com/ocornut/imgui.git', imgui_revision)
+        git.clone('https://github.com/ocornut/imgui.git', str(self.options.imgui_revision))
 
     def configure(self):
         imconfig = self.options.imconfig
         if imconfig and not os.path.isfile(str(imconfig)):
             raise ConanInvalidConfiguration("Provided ImGui config is not a file or doesn't exist")
+        if not self.options.imgui_revision:
+            raise ConanInvalidConfiguration("ImGui revision is empty. Try latest version tag or 'master'")
+
         self.options['sfml'].graphics = True
         self.options['sfml'].window = True
         self.options['sfml'].shared = self.options.shared

--- a/conanfile.py
+++ b/conanfile.py
@@ -38,7 +38,7 @@ class ImguiSFML(ConanFile):
     url = 'https://github.com/eliasdaler/imgui-sfml'
     homepage = 'https://github.com/eliasdaler/imgui-sfml'
     author = 'Elias Daler <eliasdaler@yandex.ru>'
-    build_requires = 'sfml/2.5.1@bincrafters/stable'
+    requires = 'sfml/2.5.1@bincrafters/stable'
     license = 'MIT'
     settings = 'os', 'compiler', 'build_type', 'arch'
     options = {

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import os.path
 from conans import ConanFile, CMake
 from conans.tools import Git
-import os
 
 class ImguiSFML(ConanFile):
     """ Imgui-SFML library conan file.
@@ -29,10 +29,10 @@ class ImguiSFML(ConanFile):
     name = 'ImGui-SFML'
     version = '2.0.1'
     description = 'ImGui binding for use with SFML'
-    topics = ('conan', 'sfml', 'imgui')
+    topics = ('conan', 'sfml', 'gui', 'imgui')
     url = 'https://github.com/eliasdaler/imgui-sfml'
     homepage = 'https://github.com/eliasdaler/imgui-sfml'
-    author = 'eliasdaler <eliasdaler@yandex.ru>'
+    author = 'Elias Daler <eliasdaler@yandex.ru>'
     build_requires = 'sfml/2.5.1@bincrafters/stable'
     license = 'MIT'
     settings = 'os', 'compiler', 'build_type', 'arch'
@@ -48,7 +48,8 @@ class ImguiSFML(ConanFile):
         'imconfig': None,
         'imconfig_install_folder': None
     }
-    exports_sources = ['*.cpp', '*.h', 'CMakeLists.txt', 'cmake*']
+    exports_sources = ['imgui-SFML.cpp', 'imgui-SFML.h', 'imconfig-SFML.h',
+                       'imgui-SFML_export.h', 'CMakeLists.txt', 'cmake/FindImGui.cmake']
     exports = 'LICENSE.md'
     _imgui_dir = 'imgui'
 
@@ -59,9 +60,9 @@ class ImguiSFML(ConanFile):
     def configure(self):
         self.options['sfml'].graphics = True
         self.options['sfml'].window = True
-        self.options['sfml'].shared = True
+        self.options['sfml'].shared = self.options.shared
 
-    def configure_cmake(self):
+    def _configure_cmake(self):
         cmake = CMake(self)
         cmake.definitions['IMGUI_DIR'] = os.path.join(self.source_folder, self._imgui_dir)
         cmake.definitions['SFML_DIR'] = os.path.join(self.deps_cpp_info['sfml'].lib_paths[0], 'cmake', 'SFML')
@@ -80,11 +81,11 @@ class ImguiSFML(ConanFile):
         return cmake
 
     def build(self):
-        cmake = self.configure_cmake()
+        cmake = self._configure_cmake()
         cmake.build()
 
     def package(self):
-        cmake = self.configure_cmake()
+        cmake = self._configure_cmake()
         cmake.install()
 
     def package_info(self):

--- a/conanfile.py
+++ b/conanfile.py
@@ -12,10 +12,10 @@ class ImguiSfmlConan(ConanFile):
     Options:
 
     * shared: True or False
-      Whether to build this library shared or static
+      Whether to build this library shared or static.
 
     * fPIC: True or False
-      Whether or not to use -fPIC option while building
+      Whether or not to use -fPIC option while building.
 
     * imconfig: None or String
       Use 'None' if you want this library to provide default
@@ -63,7 +63,7 @@ class ImguiSfmlConan(ConanFile):
         'imgui-SFML_export.h',
         'imgui-SFML.h',
     ]
-    exports = 'LICENSE.md'
+    exports = 'LICENSE'
     _imgui_dir = 'imgui'
 
     def source(self):
@@ -74,6 +74,8 @@ class ImguiSfmlConan(ConanFile):
         imconfig = self.options.imconfig
         if imconfig and not os.path.isfile(str(imconfig)):
             raise ConanInvalidConfiguration("Provided ImGui config is not a file or doesn't exist")
+        else:
+            self.exports_sources.append(str(imconfig))
         if not self.options.imgui_revision:
             raise ConanInvalidConfiguration("ImGui revision is empty. Try latest version tag or 'master'")
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -4,6 +4,7 @@
 import os.path
 from conans import ConanFile, CMake
 from conans.tools import Git
+from conans.errors import ConanInvalidConfiguration
 
 class ImguiSFML(ConanFile):
     """ Imgui-SFML library conan file.
@@ -58,6 +59,9 @@ class ImguiSFML(ConanFile):
         git.clone('https://github.com/ocornut/imgui.git', 'v1.69')
 
     def configure(self):
+        imconfig = self.options.imconfig
+        if imconfig and not os.path.isfile(str(imconfig)):
+            raise ConanInvalidConfiguration("Provided ImGui config is not a file or does not exists")
         self.options['sfml'].graphics = True
         self.options['sfml'].window = True
         self.options['sfml'].shared = self.options.shared

--- a/conanfile.py
+++ b/conanfile.py
@@ -23,8 +23,9 @@ class ImguiSfmlConan(ConanFile):
       imconfig.h file you want to include in the build.
 
     * imconfig_install_folder: None or String
-      Use 'None' if you want this build to include imconfig.h file,
-      otherwise use anything else.
+      Use 'None' if you want this build to include custom config
+      file, otherwise specify the directory where your imconfig
+      will be installed.
 
     * imgui_revision: String
       Tag or branch of ImGui repository that should be used with
@@ -72,10 +73,11 @@ class ImguiSfmlConan(ConanFile):
 
     def configure(self):
         imconfig = self.options.imconfig
-        if imconfig and not os.path.isfile(str(imconfig)):
-            raise ConanInvalidConfiguration("Provided ImGui config is not a file or doesn't exist")
-        else:
-            self.exports_sources.append(str(imconfig))
+        if imconfig:
+            if not os.path.isfile(str(imconfig)):
+                raise ConanInvalidConfiguration("Provided user config is not a file or doesn't exist")
+            else:
+                self._imconfig_path = os.path.abspath(str(self.options.imconfig))
         if not self.options.imgui_revision:
             raise ConanInvalidConfiguration("ImGui revision is empty. Try latest version tag or 'master'")
 
@@ -92,10 +94,9 @@ class ImguiSfmlConan(ConanFile):
         if self.options.imconfig_install_folder:
             cmake.definitions['IMGUI_SFML_CONFIG_INSTALL_DIR'] = self.options.imconfig_install_folder
         if self.options.imconfig:
-            imconfig = str(self.options.imconfig)
             cmake.definitions['IMGUI_SFML_USE_DEFAULT_CONFIG'] = 'OFF'
-            cmake.definitions['IMGUI_SFML_CONFIG_NAME'] = os.path.basename(imconfig)
-            cmake.definitions['IMGUI_SFML_CONFIG_DIR'] = os.path.dirname(imconfig)
+            cmake.definitions['IMGUI_SFML_CONFIG_NAME'] = os.path.basename(self._imconfig_path)
+            cmake.definitions['IMGUI_SFML_CONFIG_DIR'] = os.path.dirname(self._imconfig_path)
         else:
             cmake.definitions['IMGUI_SFML_USE_DEFAULT_CONFIG'] = 'ON'
         cmake.configure()

--- a/conanfile.py
+++ b/conanfile.py
@@ -33,7 +33,7 @@ class ImguiSfmlConan(ConanFile):
     """
 
     name = 'imgui-sfml'
-    version = '2.0.1'
+    version = '2.0.2'
     description = 'ImGui binding for use with SFML'
     topics = ('conan', 'sfml', 'gui', 'imgui')
     url = 'https://github.com/eliasdaler/imgui-sfml'

--- a/conanfile.py
+++ b/conanfile.py
@@ -25,6 +25,10 @@ class ImguiSFML(ConanFile):
     * imconfig_install_folder: None or String
       Use 'None' if you want this build to include imconfig.h file,
       otherwise use anything else.
+
+    * imgui_revision: None or String
+      Tag or branch of ImGui repository that should be patched with
+      ImGui-SFML. 'None' will results in master branch.
     """
 
     name = 'ImGui-SFML'
@@ -41,13 +45,15 @@ class ImguiSFML(ConanFile):
         'shared': [True, False],
         'fPIC': [True, False],
         'imconfig': 'ANY',
-        'imconfig_install_folder': 'ANY'
+        'imconfig_install_folder': 'ANY',
+        'imgui_revision': 'ANY'
     }
     default_options = {
         'shared': False,
         'fPIC': True,
         'imconfig': None,
-        'imconfig_install_folder': None
+        'imconfig_install_folder': None,
+        'imgui_revision': 'v1.70'
     }
     exports_sources = [
         'imgui-SFML.cpp',
@@ -61,8 +67,9 @@ class ImguiSFML(ConanFile):
     _imgui_dir = 'imgui'
 
     def source(self):
+        imgui_revision = str(self.options.imgui_revision) if self.options.imgui_revision else 'master'
         git = Git(folder=self._imgui_dir)
-        git.clone('https://github.com/ocornut/imgui.git', 'v1.69')
+        git.clone('https://github.com/ocornut/imgui.git', imgui_revision)
 
     def configure(self):
         imconfig = self.options.imconfig

--- a/conanfile.py
+++ b/conanfile.py
@@ -49,8 +49,14 @@ class ImguiSFML(ConanFile):
         'imconfig': None,
         'imconfig_install_folder': None
     }
-    exports_sources = ['imgui-SFML.cpp', 'imgui-SFML.h', 'imconfig-SFML.h',
-                       'imgui-SFML_export.h', 'CMakeLists.txt', 'cmake/FindImGui.cmake']
+    exports_sources = [
+        'imgui-SFML.cpp',
+        'imgui-SFML.h',
+        'imconfig-SFML.h',
+        'imgui-SFML_export.h',
+        'CMakeLists.txt',
+        'cmake/FindImGui.cmake'
+    ]
     exports = 'LICENSE.md'
     _imgui_dir = 'imgui'
 
@@ -61,7 +67,7 @@ class ImguiSFML(ConanFile):
     def configure(self):
         imconfig = self.options.imconfig
         if imconfig and not os.path.isfile(str(imconfig)):
-            raise ConanInvalidConfiguration("Provided ImGui config is not a file or does not exists")
+            raise ConanInvalidConfiguration("Provided ImGui config is not a file or doesn't exist")
         self.options['sfml'].graphics = True
         self.options['sfml'].window = True
         self.options['sfml'].shared = self.options.shared

--- a/conanfile.py
+++ b/conanfile.py
@@ -6,7 +6,7 @@ from conans import ConanFile, CMake
 from conans.tools import Git
 from conans.errors import ConanInvalidConfiguration
 
-class ImguiSFML(ConanFile):
+class ImguiSfmlConan(ConanFile):
     """ Imgui-SFML library conan file.
 
     Options:
@@ -31,7 +31,7 @@ class ImguiSFML(ConanFile):
       ImGui-SFML.
     """
 
-    name = 'ImGui-SFML'
+    name = 'imgui-sfml'
     version = '2.0.1'
     description = 'ImGui binding for use with SFML'
     topics = ('conan', 'sfml', 'gui', 'imgui')

--- a/conanfile.py
+++ b/conanfile.py
@@ -16,72 +16,66 @@ class ImguiSFML(ConanFile):
     * fPIC: True or False
       Whether or not to use -fPIC option while building
 
-    * examples: True or False
-      Whether or not to build examples
-
     * imconfig: None or String
-      Use "None" if you want this library to provide the default
+      Use 'None' if you want this library to provide default
       ImGui's imconfig.h file. Otherwise, provide a path to the
       imconfig.h file you want to include in the build.
 
     * imconfig_install_folder: None or String
-      Use "None" if you want this build to include imconfig.h file,
+      Use 'None' if you want this build to include imconfig.h file,
       otherwise use anything else.
     """
 
     name = 'ImGui-SFML'
-    version = '2.0'
+    version = '2.0.1'
     description = 'ImGui binding for use with SFML'
     topics = ('conan', 'sfml', 'imgui')
     url = 'https://github.com/eliasdaler/imgui-sfml'
     homepage = 'https://github.com/eliasdaler/imgui-sfml'
     author = 'eliasdaler <eliasdaler@yandex.ru>'
-    build_requires = 'sfml/[>=2.5.0]@bincrafters/stable'
-    license = 'MIT License'
+    build_requires = 'sfml/2.5.1@bincrafters/stable'
+    license = 'MIT'
     settings = 'os', 'compiler', 'build_type', 'arch'
     options = {
         'shared': [True, False],
         'fPIC': [True, False],
-        'examples': [True, False],
-        'imconfig': "ANY",
-        'imconfig_install_folder': "ANY"
+        'imconfig': 'ANY',
+        'imconfig_install_folder': 'ANY'
     }
     default_options = {
         'shared': False,
         'fPIC': True,
-        'examples': False,
         'imconfig': None,
         'imconfig_install_folder': None
     }
-    _imgui_dir = "imgui"
+    exports_sources = ['*.cpp', '*.h', 'CMakeLists.txt', 'cmake*']
+    exports = 'LICENSE.md'
+    _imgui_dir = 'imgui'
 
     def source(self):
-        # TODO: change to 2.0 tag when it's ready
-        git = Git()
-        git.clone("https://github.com/eliasdaler/imgui-sfml.git", "develop")
-
         git = Git(folder=self._imgui_dir)
-        git.clone("https://github.com/ocornut/imgui.git", "v1.69")
+        git.clone('https://github.com/ocornut/imgui.git', 'v1.69')
 
     def configure(self):
-        self.options["sfml"].graphics = True
-        self.options["sfml"].window = True
-        self.options["sfml"].shared = True
+        self.options['sfml'].graphics = True
+        self.options['sfml'].window = True
+        self.options['sfml'].shared = True
 
     def configure_cmake(self):
         cmake = CMake(self)
-        cmake.definitions["IMGUI_DIR"] = os.path.join(self.source_folder, self._imgui_dir)
-        cmake.definitions["SFML_DIR"] = os.path.join(self.deps_cpp_info['sfml'].lib_paths[0], 'cmake', 'SFML')
-        cmake.definitions["IMGUI_SFML_BUILD_EXAMPLES"] = self.options.examples
-        cmake.definitions["IMGUI_SFML_FIND_SFML"] = "ON"
-        if self.options.imconfig_install_folder is not None:
-            cmake.definitions["IMGUI_SFML_CONFIG_INSTALL_DIR"] = self.options.imconfig_install_folder
-        if self.options.imconfig is not None:
-            cmake.definitions["IMGUI_SFML_USE_DEFAULT_CONFIG"] = False
-            cmake.definitions["IMGUI_SFML_CONFIG_NAME"] = os.path.basename(self.options.imconfig)
-            cmake.definitions["IMGUI_SFML_CONFIG_DIR"] = os.path.dirname(self.options.imconfig)
+        cmake.definitions['IMGUI_DIR'] = os.path.join(self.source_folder, self._imgui_dir)
+        cmake.definitions['SFML_DIR'] = os.path.join(self.deps_cpp_info['sfml'].lib_paths[0], 'cmake', 'SFML')
+        cmake.definitions['IMGUI_SFML_BUILD_EXAMPLES'] = 'OFF'
+        cmake.definitions['IMGUI_SFML_FIND_SFML'] = 'ON'
+        if self.options.imconfig_install_folder:
+            cmake.definitions['IMGUI_SFML_CONFIG_INSTALL_DIR'] = self.options.imconfig_install_folder
+        if self.options.imconfig:
+            imconfig = str(self.options.imconfig)
+            cmake.definitions['IMGUI_SFML_USE_DEFAULT_CONFIG'] = 'OFF'
+            cmake.definitions['IMGUI_SFML_CONFIG_NAME'] = os.path.basename(imconfig)
+            cmake.definitions['IMGUI_SFML_CONFIG_DIR'] = os.path.dirname(imconfig)
         else:
-            cmake.definitions["IMGUI_SFML_USE_DEFAULT_CONFIG"] = True
+            cmake.definitions['IMGUI_SFML_USE_DEFAULT_CONFIG'] = 'ON'
         cmake.configure()
         return cmake
 
@@ -94,4 +88,4 @@ class ImguiSFML(ConanFile):
         cmake.install()
 
     def package_info(self):
-        self.cpp_info.libs = ["ImGui-SFML"]
+        self.cpp_info.libs = ['ImGui-SFML']

--- a/conanfile.py
+++ b/conanfile.py
@@ -27,7 +27,7 @@ class ImguiSFML(ConanFile):
       otherwise use anything else.
 
     * imgui_revision: None or String
-      Tag or branch of ImGui repository that should be patched with
+      Tag or branch of ImGui repository that should be used with
       ImGui-SFML. 'None' will results in master branch.
     """
 
@@ -56,12 +56,12 @@ class ImguiSFML(ConanFile):
         'imgui_revision': 'v1.70'
     }
     exports_sources = [
-        'imgui-SFML.cpp',
-        'imgui-SFML.h',
-        'imconfig-SFML.h',
-        'imgui-SFML_export.h',
-        'CMakeLists.txt',
         'cmake/FindImGui.cmake'
+        'CMakeLists.txt',
+        'imconfig-SFML.h',
+        'imgui-SFML.cpp',
+        'imgui-SFML_export.h',
+        'imgui-SFML.h',
     ]
     exports = 'LICENSE.md'
     _imgui_dir = 'imgui'

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from conans import ConanFile, CMake
+from conans.tools import Git
+import os
+
+class ImguiSFML(ConanFile):
+    """ Imgui-SFML library conan file.
+
+    Options:
+
+    * shared: True or False
+      Whether to build this library shared or static
+
+    * fPIC: True or False
+      Whether or not to use -fPIC option while building
+
+    * examples: True or False
+      Whether or not to build examples
+
+    * imconfig: None or String
+      Use "None" if you want this library to provide the default
+      ImGui's imconfig.h file. Otherwise, provide a path to the
+      imconfig.h file you want to include in the build.
+
+    * imconfig_install_folder: None or String
+      Use "None" if you want this build to include imconfig.h file,
+      otherwise use anything else.
+    """
+
+    name = 'ImGui-SFML'
+    version = '2.0'
+    description = 'ImGui binding for use with SFML'
+    topics = ('conan', 'sfml', 'imgui')
+    url = 'https://github.com/eliasdaler/imgui-sfml'
+    homepage = 'https://github.com/eliasdaler/imgui-sfml'
+    author = 'eliasdaler <eliasdaler@yandex.ru>'
+    build_requires = 'sfml/[>=2.5.0]@bincrafters/stable'
+    license = 'MIT License'
+    settings = 'os', 'compiler', 'build_type', 'arch'
+    options = {
+        'shared': [True, False],
+        'fPIC': [True, False],
+        'examples': [True, False],
+        'imconfig': "ANY",
+        'imconfig_install_folder': "ANY"
+    }
+    default_options = {
+        'shared': False,
+        'fPIC': True,
+        'examples': False,
+        'imconfig': None,
+        'imconfig_install_folder': None
+    }
+    _imgui_dir = "imgui"
+
+    def source(self):
+        # TODO: change to 2.0 tag when it's ready
+        git = Git()
+        git.clone("https://github.com/eliasdaler/imgui-sfml.git", "develop")
+
+        git = Git(folder=self._imgui_dir)
+        git.clone("https://github.com/ocornut/imgui.git", "v1.69")
+
+    def configure(self):
+        self.options["sfml"].graphics = True
+        self.options["sfml"].window = True
+        self.options["sfml"].shared = True
+
+    def configure_cmake(self):
+        cmake = CMake(self)
+        cmake.definitions["IMGUI_DIR"] = os.path.join(self.source_folder, self._imgui_dir)
+        cmake.definitions["SFML_DIR"] = os.path.join(self.deps_cpp_info['sfml'].lib_paths[0], 'cmake', 'SFML')
+        cmake.definitions["IMGUI_SFML_BUILD_EXAMPLES"] = self.options.examples
+        cmake.definitions["IMGUI_SFML_FIND_SFML"] = "ON"
+        if self.options.imconfig_install_folder is not None:
+            cmake.definitions["IMGUI_SFML_CONFIG_INSTALL_DIR"] = self.options.imconfig_install_folder
+        if self.options.imconfig is not None:
+            cmake.definitions["IMGUI_SFML_USE_DEFAULT_CONFIG"] = False
+            cmake.definitions["IMGUI_SFML_CONFIG_NAME"] = os.path.basename(self.options.imconfig)
+            cmake.definitions["IMGUI_SFML_CONFIG_DIR"] = os.path.dirname(self.options.imconfig)
+        else:
+            cmake.definitions["IMGUI_SFML_USE_DEFAULT_CONFIG"] = True
+        cmake.configure()
+        return cmake
+
+    def build(self):
+        cmake = self.configure_cmake()
+        cmake.build()
+
+    def package(self):
+        cmake = self.configure_cmake()
+        cmake.install()
+
+    def package_info(self):
+        self.cpp_info.libs = ["ImGui-SFML"]


### PR DESCRIPTION
Introducing `conanfile.py` for ImGui-SFML to ease usage for people who want to use it as a dependency in a conan project. 

Using `conan create . user/stable` is enough to build a package localy, however, it would be much nicer to [submit an inclusion request](https://docs.conan.io/en/latest/uploading_packages/bintray/conan_center_guide.html) to **conan-center**. This way, people can just use *imgui-sfml/2.0.1@conan/stable* or something like that in their recipies. Another alternative is **Bincrafters**, although I'm not familiar with their inclusion politics.

I didn't change README.md to reflect new conan package because at the moment I don't know at what conan remote, channel or user this package will be. Also, because of that, I'm marking this PR as a draft to discuss the situation.