### PR TITLE
Fix clipboard for unicode strings

### DIFF
--- a/imgui-SFML.cpp
+++ b/imgui-SFML.cpp
@@ -876,11 +876,12 @@ void updateJoystickLStickState(ImGuiIO& io) {
 }
 
 void setClipboardText(void* /*userData*/, const char* text) {
-    sf::Clipboard::setString(text);
+    sf::Clipboard::setString(sf::String::fromUtf8(text, text + std::strlen(text)));
 }
 
 const char* getClipboadText(void* /*userData*/) {
-    s_clipboardText = sf::Clipboard::getString().toAnsiString();
+    std::basic_string<sf::Uint8> tmp = sf::Clipboard::getString().toUtf8();
+    s_clipboardText = std::string(tmp.begin(), tmp.end());
     return s_clipboardText.c_str();
 }
 


### PR DESCRIPTION
Imgui uses UTF-8 for the internal representation of its strings. On the other side SFML uses UTF-32 in its `sf::String`.
The problem is when the `toAnsiString` method is called, the comportment of this method is to discard chars that don't fit in the current encoding (`std::locale()`), so if you copy/paste a non-ansi char (for example ひ), it doesn't work.
To address this problem I used the `toUtf8` method that convert the UTF-32 string to an UTF-8 one.

An other solution to fix this problem is to convert `s_clipboardText` to a `std::basic_string<unsigned char>` and to use the following code: 
```cpp
const char* getClipboadText(void* /*userData*/) {
    s_clipboardText = sf::Clipboard::getString().toUtf8();
    return reinterpret_cast<const char*>(s_clipboardText.c_str());
}
```
But I am not sure if this well defined by the C++ standard.

EDIT: It seems to be safe (https://stackoverflow.com/a/15172304)