### PR TITLE
Added KeySuper update (fixes the inability to use shortcuts on macOS)

### DIFF
--- a/imgui-SFML.cpp
+++ b/imgui-SFML.cpp
@@ -395,13 +395,15 @@ void Update(const sf::Vector2i& mousePos, const sf::Vector2f& displaySize,
         }
     }
 
-    // Update Ctrl, Shift, Alt state
+    // Update Ctrl, Shift, Alt, Super state
     io.KeyCtrl = io.KeysDown[sf::Keyboard::LControl] ||
                  io.KeysDown[sf::Keyboard::RControl];
     io.KeyAlt =
         io.KeysDown[sf::Keyboard::LAlt] || io.KeysDown[sf::Keyboard::RAlt];
     io.KeyShift =
         io.KeysDown[sf::Keyboard::LShift] || io.KeysDown[sf::Keyboard::RShift];
+    io.KeySuper = io.KeysDown[sf::Keyboard::LSystem] ||
+                  io.KeysDown[sf::Keyboard::RSystem];
 
 #ifdef ANDROID
 #ifdef USE_JNI


### PR DESCRIPTION
ImGUI uses the io.KeySuper instead of Ctrl on macOS for shortcuts, but there isn't an implementation on how KeySuper is setted, so doing any shortcut does nothing. This PR fixes that.