### PR TITLE
Filter some characters that imgui already handles

### DIFF
--- a/imgui-SFML.cpp
+++ b/imgui-SFML.cpp
@@ -314,10 +314,11 @@ void ProcessEvent(const sf::Event& event) {
                     (event.type == sf::Event::KeyPressed);
                 break;
             case sf::Event::TextEntered:
-                if (event.text.unicode > 0 && event.text.unicode < 0x10000) {
-                    io.AddInputCharacter(
-                        static_cast<ImWchar>(event.text.unicode));
+                // Don't handle the event for unprintable characters
+                if (event.text.unicode < ' ' || event.text.unicode == 127) {
+                    break;
                 }
+                io.AddInputCharacter(event.text.unicode);
                 break;
             case sf::Event::JoystickConnected:
                 if (s_joystickId == NULL_JOYSTICK_ID) {


### PR DESCRIPTION
This is what this pr changes:
- Removed the char filter under 0x10000 (it's no more needed after [this commit](https://github.com/ocornut/imgui/commit/ef13d95466f27b4a955d6f95da90822001ace25f))
- Removed the cast to ImWchar (it's no more needed after the commit linked above)
- Added a filter to \n (line feed), \r (carriage return), \t (tab) and \b (backspace) which are all handled inside ImGui (fixes the double linefeed bug in macOS #91)