### PR TITLE
Add option to use static SFML libraries to CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ endif()
 
 option(IMGUI_SFML_BUILD_EXAMPLES "Build ImGui_SFML examples" OFF)
 option(IMGUI_SFML_FIND_SFML "Use find_package to find SFML" ON)
+option(IMGUI_SFML_USE_STATIC_LIBS "Use static SFML librares" ON)
 
 # If you want to use your own user config when compiling ImGui, please set the following variables
 # For example, if you have your config in /path/to/dir/with/config/myconfig.h, set the variables as follows:
@@ -32,6 +33,9 @@ set(IMGUI_SFML_CONFIG_INSTALL_DIR "" CACHE PATH "Path where user's config header
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
 
 if (IMGUI_SFML_FIND_SFML)
+	if (IMGUI_SFML_USE_STATIC_LIBS)
+		set(SFML_STATIC_LIBRARIES TRUE)
+	endif()
 	find_package(SFML 2.5 COMPONENTS graphics system window)
 
 	if(NOT SFML_FOUND)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,6 @@ endif()
 
 option(IMGUI_SFML_BUILD_EXAMPLES "Build ImGui_SFML examples" OFF)
 option(IMGUI_SFML_FIND_SFML "Use find_package to find SFML" ON)
-option(IMGUI_SFML_USE_STATIC_LIBS "Use static SFML librares" OFF)
 
 # If you want to use your own user config when compiling ImGui, please set the following variables
 # For example, if you have your config in /path/to/dir/with/config/myconfig.h, set the variables as follows:
@@ -33,7 +32,7 @@ set(IMGUI_SFML_CONFIG_INSTALL_DIR "" CACHE PATH "Path where user's config header
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
 
 if (IMGUI_SFML_FIND_SFML)
-	if (IMGUI_SFML_USE_STATIC_LIBS)
+	if (NOT BUILD_SHARED_LIBS)
 		set(SFML_STATIC_LIBRARIES TRUE)
 	endif()
 	find_package(SFML 2.5 COMPONENTS graphics system window)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ endif()
 
 option(IMGUI_SFML_BUILD_EXAMPLES "Build ImGui_SFML examples" OFF)
 option(IMGUI_SFML_FIND_SFML "Use find_package to find SFML" ON)
-option(IMGUI_SFML_USE_STATIC_LIBS "Use static SFML librares" ON)
+option(IMGUI_SFML_USE_STATIC_LIBS "Use static SFML librares" OFF)
 
 # If you want to use your own user config when compiling ImGui, please set the following variables
 # For example, if you have your config in /path/to/dir/with/config/myconfig.h, set the variables as follows:


### PR DESCRIPTION
I was trying to use CMake to compile ImGui-SFML but it was complaining that it couldn't find it, and I deduced that it was because my SFML libraries are built as static libs. Added this to make it work and thought I'd share.