### PR TITLE
Rename SFML::ShowTestWindow to SFML::ShowDemoWindow

### DIFF
--- a/examples/main.cpp
+++ b/examples/main.cpp
@@ -28,7 +28,7 @@ int main()
 
         ImGui::SFML::Update(window, deltaClock.restart());
 
-        ImGui::ShowTestWindow();
+        ImGui::ShowDemoWindow();
         
         ImGui::Begin("Hello, world!");
         ImGui::Button("Look at this pretty button");


### PR DESCRIPTION
According to the imgui changelog v1.53 of imgui deprecated `SFML::ShowTestWindow`. It kept the function around for a while until v1.75 which removed the reference. This means that compiling with `IMGUI_SFML_BUILD_EXAMPLES=ON` fails with the most recent of SFML.

I've adjusted the main.cpp to use `SFML::ShowDemoWindow`