### PR TITLE
Added IMGUI_SFML_IMGUI_DEMO option to CMake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,7 @@ find_package(OpenGL REQUIRED)
 add_library(ImGui-SFML
   imgui-SFML.cpp
   ${IMGUI_SOURCES}
+  $<$<BOOL:${IMGUI_SFML_IMGUI_DEMO}>:${IMGUI_DEMO_SOURCES}>
 )
 
 # Add pretty alias

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ endif()
 
 option(IMGUI_SFML_BUILD_EXAMPLES "Build ImGui_SFML examples" OFF)
 option(IMGUI_SFML_FIND_SFML "Use find_package to find SFML" ON)
+option(IMGUI_SFML_IMGUI_DEMO "Build imgui_demo.cpp" OFF)
 
 # If you want to use your own user config when compiling ImGui, please set the following variables
 # For example, if you have your config in /path/to/dir/with/config/myconfig.h, set the variables as follows:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,10 @@ set(IMGUI_PUBLIC_HEADERS
   ${IMGUI_INCLUDE_DIR}/misc/cpp/imgui_stdlib.h
 )
 
+if (IMGUI_SFML_IMGUI_DEMO)
+    list(APPEND IMGUI_SOURCES ${IMGUI_DEMO_SOURCES})
+endif()
+
 # CMake 3.11 and later prefer to choose GLVND, but we choose legacy OpenGL just because it's safer
 # (unless the OpenGL_GL_PREFERENCE was explicitly set)
 # See CMP0072 for more details (cmake --help-policy CMP0072)
@@ -76,7 +80,6 @@ find_package(OpenGL REQUIRED)
 add_library(ImGui-SFML
   imgui-SFML.cpp
   ${IMGUI_SOURCES}
-  $<$<BOOL:${IMGUI_SFML_IMGUI_DEMO}>:${IMGUI_DEMO_SOURCES}>
 )
 
 # Add pretty alias

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ cmake <ImGui-SFML repo folder> -DIMGUI_DIR=<ImGui repo folder> -DSFML_DIR=<path 
 If you have SFML installed on your system, you don't need to set SFML_DIR during
 configuration.
 
-You can also specify `BUILD_SHARED_LIBS=ON` to build ImGui-SFML as a shared library. To build ImGui-SFML examples, set `IMGUI_SFML_BUILD_EXAMPLES=ON`. To build imgui-demo.cpp, set `IMGUI_SFML_IMGUI_DEMO=ON`.
+You can also specify `BUILD_SHARED_LIBS=ON` to build ImGui-SFML as a shared library. To build ImGui-SFML examples, set `IMGUI_SFML_BUILD_EXAMPLES=ON`. To build imgui-demo.cpp (to be able to use `ImGui::ShowDemoWindow`), set `IMGUI_SFML_IMGUI_DEMO=ON`.
 
 After the building, you can install the library on your system by running:
 ```sh

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ cmake <ImGui-SFML repo folder> -DIMGUI_DIR=<ImGui repo folder> -DSFML_DIR=<path 
 If you have SFML installed on your system, you don't need to set SFML_DIR during
 configuration.
 
-You can also specify `BUILD_SHARED_LIBS=ON` to build ImGui-SFML as a shared library. To build ImGui-SFML examples, set `IMGUI_SFML_BUILD_EXAMPLES=ON`.
+You can also specify `BUILD_SHARED_LIBS=ON` to build ImGui-SFML as a shared library. To build ImGui-SFML examples, set `IMGUI_SFML_BUILD_EXAMPLES=ON`. To build imgui-demo.cpp, set `IMGUI_SFML_IMGUI_DEMO=ON`.
 
 After the building, you can install the library on your system by running:
 ```sh


### PR DESCRIPTION
Enabling it will result in compiling imgui_demo.cpp file, that contains e.g. ImGui::ShowDemoWindow function, which is useful for new users.

Resolves: #121