### PR TITLE
Two CMake quality of life improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,6 +136,9 @@ if(BUILD_SHARED_LIBS)
   set_target_properties(ImGui-SFML PROPERTIES
     DEFINE_SYMBOL "IMGUI_SFML_EXPORTS"
   )
+  set_target_properties(ImGui-SFML PROPERTIES
+    DEBUG_POSTFIX "_d"
+  )
 endif()
 
 set(IMGUI_SFML_PUBLIC_HEADERS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,11 @@ project(imgui_sfml
   VERSION 2.1
 )
 
+# In CMake 3.12+ this policy will automatically take the ImGui_ROOT and SFML_ROOT environment variables
+# into account as hints for the find_package calls.
+if(POLICY CMP0074)
+  cmake_policy(SET CMP0074 NEW)
+endif()
 # In CMake 3.13+ this policy enables you to define normal variables with option names as if you defined
 # these options. Useful for add_subdirectory(ImGui-SFML)
 if(POLICY CMP0077)


### PR DESCRIPTION
This PR combines two minor CMake improvements that are particularly useful to Windows users.

The first one activates the CMake policy [CMP0074](https://cmake.org/cmake/help/latest/policy/CMP0074.html) if it's available (CMake 3.12+). This will cause calls to `find_package()` to take into account `*_ROOT` environment variables as hints for a package's location. So instead of passing `-DIMGUI_DIR=` and `-DSFML_DIR=` on the CMake command line, one can now set the `ImGui_ROOT` and `SFML_ROOT` environment variables instead. If the policy is not set but those environment variables are found, CMake will just output a nasty policy warning on versions 3.12+.

The second change adds a debug postfix for the library. This is something that mostly developers working with the Visual Studio (MSVC) toolchain will care about. On MSVC, the debug and release runtimes are incompatible. Without this change, if I build and install the library to a folder, it will always overwrite the library binaries to the most recently installed configuration. So if I first install the Debug configuration and then install the Release configuration, the resulting installation will contain two CMake configurations (one `ImGui-SFMLConfig-debug.cmake` and one `ImGui-SFMLConfig-release.cmake`), but the Debug configuration will be broken because the library binaries will have been overwritten by the (incompatible) Release version.
By adding the debug postfix, the debug configuration will use different filenames, (`ImGui-SFML_d` instead of `ImGui-SFML`) which resolves this problem.

Some people don't like the Debug postfix because the resulting library filename looks weird. The alternative to resolve this is to use per-configuration subdirectories for the installation. So instead of just installing all the libraries to `lib`, you would install to `lib/$<CONFIG>`. This complicates the directory tree, but leaves the library filenames as they were. If requested, I can change the PR to use that approach instead.

I am no expert at Conan, but to me it looks like the Conan script should still work as-is with the debug postfix change in place. But it would be great if someone with more experience in Conan could double-check that.
