### PR TITLE
CI with Travis + AppVeyor + GitHub Actions (#84)

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,90 @@
+environment:
+  matrix:
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      configuration: Debug
+      platform: x86
+      generator: "Visual Studio 14 2015"
+
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      configuration: Debug
+      platform: x64
+      generator: "Visual Studio 14 2015"
+
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      configuration: Release
+      platform: x86
+      generator: "Visual Studio 14 2015"
+
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      configuration: Release
+      platform: x64
+      generator: "Visual Studio 14 2015"
+
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      configuration: Debug
+      platform: x86
+      generator: "Visual Studio 15 2017"
+
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      configuration: Debug
+      platform: x64
+      generator: "Visual Studio 15 2017"
+
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      configuration: Release
+      platform: x86
+      generator: "Visual Studio 15 2017"
+
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      configuration: Release
+      platform: x64
+      generator: "Visual Studio 15 2017"
+
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      configuration: Debug
+      platform: x86
+      generator: "Visual Studio 16 2019"
+
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      configuration: Debug
+      platform: x64
+      generator: "Visual Studio 16 2019"
+
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      configuration: Release
+      platform: x86
+      generator: "Visual Studio 16 2019"
+
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      configuration: Release
+      platform: x64
+      generator: "Visual Studio 16 2019"
+
+init:
+  # Variables
+  - if "%platform%"=="x86" (set generator_platform=Win32) else (set generator_platform=x64)
+  # Info
+  - cmake --version
+  - msbuild /version
+
+install:
+  - git submodule update --init --recursive
+
+  # SFML
+  - git clone --recurse --depth 1 https://github.com/SFML/SFML "%TMP%/sfml_local"
+  - pushd "%TMP%/sfml_local"
+  - mkdir cmake-build
+  - pushd cmake-build
+  - mkdir "%TMP%/sfml_install"
+  - cmake -G "%generator%" -A "%generator_platform%" -DCMAKE_CONFIGURATION_TYPES="%configuration%" -DCMAKE_BUILD_TYPE="%configuration%" -DCMAKE_INSTALL_PREFIX="%TMP%/sfml_install" ..
+  - cmake --build . --config "%configuration%" --target install -- /M
+
+  # Dear ImGui
+  - git clone --recurse --depth 1 https://github.com/ocornut/imgui %TMP%/imgui_local
+
+build_script:
+  - pushd "%APPVEYOR_BUILD_FOLDER%"
+  - mkdir cmake-build
+  - pushd cmake-build
+  - cmake -G "%generator%" -A "%generator_platform%" -DCMAKE_CONFIGURATION_TYPES="%configuration%" -DCMAKE_BUILD_TYPE="%configuration%" -DCMAKE_PREFIX_PATH="%TMP%/sfml_install" -DSFML_DIR="%TMP%/sfml_install" -DIMGUI_DIR="%TMP%/imgui_local" -DBUILD_SHARED_LIBS=ON ..
+  - cmake --build . --config "%configuration%" -- /M

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,323 @@
+name: build
+
+on:
+  - push
+  - pull_request
+
+env:
+  CMAKE_VERSION: 3.17.0
+  NINJA_VERSION: 1.10.0
+  CCACHE_VERSION: 3.7.7
+
+jobs:
+  build:
+    name: ${{ matrix.config.name }}
+    runs-on: ${{ matrix.config.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+        - {
+            name: "Windows Latest - MSVC - Debug",
+            os: windows-latest,
+            cc: "cl",
+            cxx: "cl",
+            environment_script: "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Auxiliary/Build/vcvars64.bat",
+            build_type: Debug
+          }
+        - {
+            name: "Windows Latest - MSVC - Release",
+            os: windows-latest,
+            cc: "cl",
+            cxx: "cl",
+            environment_script: "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Auxiliary/Build/vcvars64.bat",
+            build_type: Release
+          }
+        - {
+            name: "Windows Latest - MinGW - Debug",
+            os: windows-latest,
+            cc: "gcc",
+            cxx: "g++",
+            build_type: Debug
+          }
+        - {
+            name: "Windows Latest - MinGW - Release",
+            os: windows-latest,
+            cc: "gcc",
+            cxx: "g++",
+            build_type: Release
+          }
+        - {
+            name: "Ubuntu Latest - GCC - Debug",
+            os: ubuntu-latest,
+            cc: "gcc",
+            cxx: "g++",
+            build_type: Debug
+          }
+        - {
+            name: "Ubuntu Latest - GCC - Release",
+            os: ubuntu-latest,
+            cc: "gcc",
+            cxx: "g++",
+            build_type: Release
+          }
+        - {
+            name: "Ubuntu Latest - Clang - Debug",
+            os: ubuntu-latest,
+            cc: "clang",
+            cxx: "clang++",
+            build_type: Debug
+          }
+        - {
+            name: "Ubuntu Latest - Clang - Release",
+            os: ubuntu-latest,
+            cc: "clang",
+            cxx: "clang++",
+            build_type: Release
+          }
+        - {
+            name: "macOS Latest - GCC - Debug",
+            os: macos-latest,
+            cc: "gcc",
+            cxx: "g++",
+            build_type: Debug
+          }
+        - {
+            name: "macOS Latest - GCC - Release",
+            os: macos-latest,
+            cc: "gcc",
+            cxx: "g++",
+            build_type: Release
+          }
+        - {
+            name: "macOS Latest - Clang - Debug",
+            os: macos-latest,
+            cc: "clang",
+            cxx: "clang++",
+            build_type: Debug
+          }
+        - {
+            name: "macOS Latest - Clang - Release",
+            os: macos-latest,
+            cc: "clang",
+            cxx: "clang++",
+            build_type: Release
+          }
+
+    steps:
+    - name: Checkout ImGui-SFML
+      uses: actions/checkout@v2
+      with:
+        submodules: recursive
+        path: imgui-sfml
+
+    - name: Checkout SFML
+      uses: actions/checkout@v2
+      with:
+        repository: SFML/SFML
+        submodules: recursive
+        path: SFML
+
+    - name: Checkout Dear ImGui
+      uses: actions/checkout@v2
+      with:
+        repository: ocornut/imgui
+        submodules: recursive
+        path: imgui
+
+    - name: Download CMake
+      id: cmake
+      shell: cmake -P {0}
+      run: |
+        set(cmake_version $ENV{CMAKE_VERSION})
+        message(STATUS "Using host CMake version: ${CMAKE_VERSION}")
+        if ("${{ runner.os }}" STREQUAL "Windows")
+          set(cmake_suffix "win64-x64.zip")
+          set(cmake_dir "cmake-${cmake_version}-win64-x64/bin")
+        elseif ("${{ runner.os }}" STREQUAL "Linux")
+          set(cmake_suffix "Linux-x86_64.tar.gz")
+          set(cmake_dir "cmake-${cmake_version}-Linux-x86_64/bin")
+        elseif ("${{ runner.os }}" STREQUAL "macOS")
+          set(cmake_suffix "Darwin-x86_64.tar.gz")
+          set(cmake_dir "cmake-${cmake_version}-Darwin-x86_64/CMake.app/Contents/bin")
+        endif()
+        set(cmake_url "https://github.com/Kitware/CMake/releases/download/v${cmake_version}/cmake-${cmake_version}-${cmake_suffix}")
+        file(DOWNLOAD "${cmake_url}" ./cmake.zip SHOW_PROGRESS)
+        execute_process(COMMAND ${CMAKE_COMMAND} -E tar xvf ./cmake.zip)
+        file(TO_CMAKE_PATH "$ENV{GITHUB_WORKSPACE}/${cmake_dir}/cmake" cmake_binary)
+        if (NOT "${{ runner.os }}" STREQUAL "Windows")
+          execute_process(COMMAND chmod +x ${cmake_binary})
+        endif()
+        message("::set-output name=cmake_binary::${cmake_binary}")
+
+    - name: Download Ninja
+      id: ninja
+      shell: cmake -P {0}
+      run: |
+        set(ninja_version $ENV{NINJA_VERSION})
+        message(STATUS "Using host CMake version: ${CMAKE_VERSION}")
+        if ("${{ runner.os }}" STREQUAL "Windows")
+          set(ninja_suffix "win.zip")
+        elseif ("${{ runner.os }}" STREQUAL "Linux")
+          set(ninja_suffix "linux.zip")
+        elseif ("${{ runner.os }}" STREQUAL "macOS")
+          set(ninja_suffix "mac.zip")
+        endif()
+        set(ninja_url "https://github.com/ninja-build/ninja/releases/download/v${ninja_version}/ninja-${ninja_suffix}")
+        file(DOWNLOAD "${ninja_url}" ./ninja.zip SHOW_PROGRESS)
+        execute_process(COMMAND ${CMAKE_COMMAND} -E tar xvf ./ninja.zip)
+        file(TO_CMAKE_PATH "$ENV{GITHUB_WORKSPACE}/ninja" ninja_binary)
+        if (NOT "${{ runner.os }}" STREQUAL "Windows")
+          execute_process(COMMAND chmod +x ${ninja_binary})
+        endif()
+        message("::set-output name=ninja_binary::${ninja_binary}")
+
+    - name: Download ccache
+      id: ccache
+      shell: cmake -P {0}
+      run: |
+        set(ccache_url "https://github.com/cristianadam/ccache/releases/download/v$ENV{CCACHE_VERSION}/${{ runner.os }}.tar.xz")
+        file(DOWNLOAD "${ccache_url}" ./ccache.tar.xz SHOW_PROGRESS)
+        execute_process(COMMAND ${CMAKE_COMMAND} -E tar xvf ./ccache.tar.xz)
+        file(TO_CMAKE_PATH "$ENV{GITHUB_WORKSPACE}/ccache" ccache_binary)
+        if (NOT "${{ runner.os }}" STREQUAL "Windows")
+          execute_process(COMMAND chmod +x ${ccache_binary})
+        endif()
+        message("::set-output name=ccache_binary::${ccache_binary}")
+
+    - name: Configure ccache
+      id: configure_ccache
+      shell: cmake -P {0}
+      run: |
+        file(TO_CMAKE_PATH "$ENV{GITHUB_WORKSPACE}" ccache_basedir)
+        message("::set-env name=CCACHE_BASEDIR::${ccache_basedir}")
+        message("::set-env name=CCACHE_DIR::${ccache_basedir}/.ccache")
+        message("::set-env name=CCACHE_COMPRESS::true")
+        message("::set-env name=CCACHE_COMPRESSLEVEL::6")
+        message("::set-env name=CCACHE_MAXSIZE::400M")
+        execute_process(COMMAND ${{ steps.ccache.outputs.ccache_binary }} -p)
+        execute_process(COMMAND ${{ steps.ccache.outputs.ccache_binary }} -z)
+        string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
+        message("::set-output name=timestamp::${current_date}")
+
+    - name: Cache ccache files
+      uses: actions/cache@v2
+      with:
+        path: .ccache
+        key: ${{ matrix.config.name }}-ccache-${{ steps.configure_ccache.outputs.timestamp }}
+        restore-keys: |
+          ${{ matrix.config.name }}-ccache-
+
+    - name: Prepare build environment
+      shell: cmake -P {0}
+      run: |
+        message("::set-env name=CC::${{ matrix.config.cc }}")
+        message("::set-env name=CXX::${{ matrix.config.cxx }}")
+        if ("${{ runner.os }}" STREQUAL "Linux")
+          execute_process(
+            COMMAND sudo apt-get -y install libsfml-dev libudev-dev libopenal-dev libvorbis-dev libflac-dev libxrandr-dev freeglut3-dev libjpeg-dev libfreetype6-dev libxrandr-dev libglew-dev libsndfile1-dev libopenal-dev libfreetype6-dev
+          )
+        endif()
+        if ("${{ runner.os }}" STREQUAL "Windows" AND NOT "x${{ matrix.config.environment_script }}" STREQUAL "x")
+          execute_process(
+            COMMAND "${{ matrix.config.environment_script }}" && set
+            OUTPUT_FILE environment_script_output.txt
+          )
+        endif()
+        message("::add-path::\"$ENV{GITHUB_WORKSPACE}\"")
+
+    - name: Install SFML
+      id: install_sfml
+      shell: cmake -P {0}
+      run: |
+        if ("${{ runner.os }}" STREQUAL "Windows" AND NOT "x${{ matrix.config.environment_script }}" STREQUAL "x")
+          file(STRINGS environment_script_output.txt output_lines)
+          foreach(line IN LISTS output_lines)
+            if (line MATCHES "^([a-zA-Z0-9_-]+)=(.*)$")
+              set(ENV{${CMAKE_MATCH_1}} "${CMAKE_MATCH_2}")
+            endif()
+          endforeach()
+        endif()
+        file(TO_CMAKE_PATH "$ENV{GITHUB_WORKSPACE}/sfml_install" sfml_install_dir)
+        execute_process(COMMAND ${CMAKE_COMMAND} -E make_directory ${sfml_install_dir})
+        execute_process(
+          COMMAND ${{ steps.cmake.outputs.cmake_binary }}
+            -S $ENV{GITHUB_WORKSPACE}/SFML
+            -B $ENV{GITHUB_WORKSPACE}/SFML/build
+            -D CMAKE_CONFIGURATION_TYPES=${{ matrix.config.build_type }}
+            -D CMAKE_BUILD_TYPE=${{ matrix.config.build_type }}
+            -G Ninja
+            -D CMAKE_MAKE_PROGRAM=${{ steps.ninja.outputs.ninja_binary }}
+            -D CMAKE_C_COMPILER_LAUNCHER=${{ steps.ccache.outputs.ccache_binary }}
+            -D CMAKE_CXX_COMPILER_LAUNCHER=${{ steps.ccache.outputs.ccache_binary }}
+            -D CMAKE_INSTALL_PREFIX=${sfml_install_dir}
+          RESULT_VARIABLE result
+        )
+        if (NOT result EQUAL 0)
+          message(FATAL_ERROR "SFML configure: Bad exit status")
+        endif()
+        execute_process(
+          COMMAND ${{ steps.cmake.outputs.cmake_binary }}
+            --build $ENV{GITHUB_WORKSPACE}/SFML/build
+            --config ${BUILD_TYPE}
+            --target install
+          RESULT_VARIABLE result
+        )
+        if (NOT result EQUAL 0)
+          message(FATAL_ERROR "SFML build: Bad exit status")
+        endif()
+        execute_process(COMMAND ${{ steps.ccache.outputs.ccache_binary }} -s)
+        message("::set-output name=sfml_install_dir::${sfml_install_dir}")
+
+    - name: Configure
+      shell: cmake -P {0}
+      run: |
+        if ("${{ runner.os }}" STREQUAL "Windows" AND NOT "x${{ matrix.config.environment_script }}" STREQUAL "x")
+          file(STRINGS environment_script_output.txt output_lines)
+          foreach(line IN LISTS output_lines)
+            if (line MATCHES "^([a-zA-Z0-9_-]+)=(.*)$")
+              set(ENV{${CMAKE_MATCH_1}} "${CMAKE_MATCH_2}")
+            endif()
+          endforeach()
+        endif()
+        execute_process(
+          COMMAND ${{ steps.cmake.outputs.cmake_binary }}
+            -S $ENV{GITHUB_WORKSPACE}/imgui-sfml
+            -B $ENV{GITHUB_WORKSPACE}/imgui-sfml/build
+            -D CMAKE_CONFIGURATION_TYPES=${{ matrix.config.build_type }}
+            -D CMAKE_BUILD_TYPE=${{ matrix.config.build_type }}
+            -G Ninja
+            -D CMAKE_MAKE_PROGRAM=${{ steps.ninja.outputs.ninja_binary }}
+            -D CMAKE_C_COMPILER_LAUNCHER=${{ steps.ccache.outputs.ccache_binary }}
+            -D CMAKE_CXX_COMPILER_LAUNCHER=${{ steps.ccache.outputs.ccache_binary }}
+            -D CMAKE_PREFIX_PATH=${{ steps.install_sfml.outputs.sfml_install_dir }}
+            -D SFML_DIR=${{ steps.install_sfml.outputs.sfml_install_dir }}
+            -D IMGUI_DIR=$ENV{GITHUB_WORKSPACE}/imgui
+            -D BUILD_SHARED_LIBS=ON
+          RESULT_VARIABLE result
+        )
+        if (NOT result EQUAL 0)
+          message(FATAL_ERROR "Bad exit status")
+        endif()
+
+    - name: Build
+      shell: cmake -P {0}
+      run: |
+        if ("${{ runner.os }}" STREQUAL "Windows" AND NOT "x${{ matrix.config.environment_script }}" STREQUAL "x")
+          file(STRINGS environment_script_output.txt output_lines)
+          foreach(line IN LISTS output_lines)
+            if (line MATCHES "^([a-zA-Z0-9_-]+)=(.*)$")
+              set(ENV{${CMAKE_MATCH_1}} "${CMAKE_MATCH_2}")
+            endif()
+          endforeach()
+        endif()
+        execute_process(
+          COMMAND ${{ steps.cmake.outputs.cmake_binary }}
+            --build $ENV{GITHUB_WORKSPACE}/imgui-sfml/build
+            --config ${BUILD_TYPE}
+          RESULT_VARIABLE result
+        )
+        if (NOT result EQUAL 0)
+          message(FATAL_ERROR "Build: Bad exit status")
+        endif()
+        execute_process(COMMAND ${{ steps.ccache.outputs.ccache_binary }} -s)

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,93 @@ matrix:
   include:
 # Linux
 ## GCC
+### GCC 4.8
+    - name: Linux - GCC 4.8 - Debug
+      arch: amd64
+      os: linux
+      compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-4.8
+      env:
+        - COMPILER=g++-4.8
+        - BUILD_TYPE=Debug
+
+    - name: Linux - GCC 4.8 - Release
+      arch: amd64
+      os: linux
+      compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-4.8
+      env:
+        - COMPILER=g++-4.8
+        - BUILD_TYPE=Release
+
+### GCC 5
+    - name: Linux - GCC 5 - Debug
+      arch: amd64
+      os: linux
+      compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-5
+      env:
+        - COMPILER=g++-5
+        - BUILD_TYPE=Debug
+
+    - name: Linux - GCC 5 - Release
+      arch: amd64
+      os: linux
+      compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-5
+      env:
+        - COMPILER=g++-5
+        - BUILD_TYPE=Release
+
+### GCC 6
+    - name: Linux - GCC 6 - Debug
+      arch: amd64
+      os: linux
+      compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-6
+      env:
+        - COMPILER=g++-6
+        - BUILD_TYPE=Debug
+
+    - name: Linux - GCC 6 - Release
+      arch: amd64
+      os: linux
+      compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-6
+      env:
+        - COMPILER=g++-6
+        - BUILD_TYPE=Release
+
 ### GCC 7
     - name: Linux - GCC 7 - Debug
       arch: amd64

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ git:
   depth: 1
   submodules: true
 
+cache: ccache
+
 matrix:
   include:
 # Linux
@@ -697,8 +699,9 @@ install:
       brew list git &>/dev/null || brew install git
       brew list cmake &>/dev/null || brew install cmake
       brew list ninja &>/dev/null || brew install ninja
+      brew list ccache &>/dev/null || brew install ccache
     else
-      sudo apt-get -y install git cmake ninja-build
+      sudo apt-get -y install git cmake ninja-build ccache
       sudo apt-get -y install libsfml-dev libudev-dev libopenal-dev libvorbis-dev libflac-dev libxrandr-dev freeglut3-dev libjpeg-dev libfreetype6-dev libxrandr-dev libglew-dev libsndfile1-dev libopenal-dev libfreetype6-dev
     fi
 
@@ -707,6 +710,8 @@ install:
   - cmake --version
   - ninja --version
   - ${CXX} --version
+  - ccache -p
+  - ccache -z
 
   # SFML
   - git clone --recurse --depth 1 https://github.com/SFML/SFML $HOME/sfml_local
@@ -714,7 +719,7 @@ install:
   - mkdir cmake-build
   - cd cmake-build
   - mkdir $HOME/sfml_install
-  - cmake -GNinja -DCMAKE_CONFIGURATION_TYPES=${BUILD_TYPE} -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DCMAKE_INSTALL_PREFIX=$HOME/sfml_install ..
+  - cmake -G Ninja -D CMAKE_C_COMPILER_LAUNCHER=ccache -D CMAKE_CXX_COMPILER_LAUNCHER=ccache -D CMAKE_CONFIGURATION_TYPES=${BUILD_TYPE} -D CMAKE_BUILD_TYPE=${BUILD_TYPE} -D CMAKE_INSTALL_PREFIX=$HOME/sfml_install ..
   - cmake --build . --config ${BUILD_TYPE} --target install
 
   # Dear ImGui
@@ -724,5 +729,6 @@ script:
   - cd $TRAVIS_BUILD_DIR
   - mkdir cmake-build
   - cd cmake-build
-  - cmake -GNinja -DCMAKE_CONFIGURATION_TYPES=${BUILD_TYPE} -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DCMAKE_PREFIX_PATH=$HOME/sfml_install -DSFML_DIR=$HOME/sfml_install -DIMGUI_DIR=$HOME/imgui_local -DBUILD_SHARED_LIBS=ON ..
+  - cmake -G Ninja -D CMAKE_C_COMPILER_LAUNCHER=ccache -D CMAKE_CXX_COMPILER_LAUNCHER=ccache -D CMAKE_CONFIGURATION_TYPES=${BUILD_TYPE} -D CMAKE_BUILD_TYPE=${BUILD_TYPE} -D CMAKE_PREFIX_PATH=$HOME/sfml_install -D SFML_DIR=$HOME/sfml_install -D IMGUI_DIR=$HOME/imgui_local -D BUILD_SHARED_LIBS=ON ..
   - cmake --build . --config ${BUILD_TYPE}
+  - ccache -s

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ matrix:
 ## GCC
 ### GCC 4.8
     - name: Linux - GCC 4.8 - Debug
-      arch: amd64
       os: linux
       compiler: gcc
       addons:
@@ -26,7 +25,6 @@ matrix:
         - BUILD_TYPE=Debug
 
     - name: Linux - GCC 4.8 - Release
-      arch: amd64
       os: linux
       compiler: gcc
       addons:
@@ -41,7 +39,6 @@ matrix:
 
 ### GCC 5
     - name: Linux - GCC 5 - Debug
-      arch: amd64
       os: linux
       compiler: gcc
       addons:
@@ -55,7 +52,6 @@ matrix:
         - BUILD_TYPE=Debug
 
     - name: Linux - GCC 5 - Release
-      arch: amd64
       os: linux
       compiler: gcc
       addons:
@@ -70,7 +66,6 @@ matrix:
 
 ### GCC 6
     - name: Linux - GCC 6 - Debug
-      arch: amd64
       os: linux
       compiler: gcc
       addons:
@@ -84,7 +79,6 @@ matrix:
         - BUILD_TYPE=Debug
 
     - name: Linux - GCC 6 - Release
-      arch: amd64
       os: linux
       compiler: gcc
       addons:
@@ -99,7 +93,6 @@ matrix:
 
 ### GCC 7
     - name: Linux - GCC 7 - Debug
-      arch: amd64
       os: linux
       compiler: gcc
       addons:
@@ -113,7 +106,6 @@ matrix:
         - BUILD_TYPE=Debug
 
     - name: Linux - GCC 7 - Release
-      arch: amd64
       os: linux
       compiler: gcc
       addons:
@@ -128,7 +120,6 @@ matrix:
 
 ### GCC 8
     - name: Linux - GCC 8 - Debug
-      arch: amd64
       os: linux
       compiler: gcc
       addons:
@@ -142,7 +133,6 @@ matrix:
         - BUILD_TYPE=Debug
 
     - name: Linux - GCC 8 - Release
-      arch: amd64
       os: linux
       compiler: gcc
       addons:
@@ -157,7 +147,6 @@ matrix:
 
 ### GCC 9
     - name: Linux - GCC 9 - Debug
-      arch: amd64
       os: linux
       compiler: gcc
       addons:
@@ -171,7 +160,6 @@ matrix:
         - BUILD_TYPE=Debug
 
     - name: Linux - GCC 9 - Release
-      arch: amd64
       os: linux
       compiler: gcc
       addons:
@@ -186,7 +174,6 @@ matrix:
 
 ### GCC 10
     - name: Linux - GCC 10 - Debug
-      arch: amd64
       os: linux
       compiler: gcc
       addons:
@@ -200,7 +187,6 @@ matrix:
         - BUILD_TYPE=Debug
 
     - name: Linux - GCC 10 - Release
-      arch: amd64
       os: linux
       compiler: gcc
       addons:
@@ -216,7 +202,6 @@ matrix:
 ## Clang
 ### Clang 3.9
     - name: Linux - Clang 3.9 - Debug
-      arch: amd64
       os: linux
       compiler: clang
       addons:
@@ -232,7 +217,6 @@ matrix:
         - BUILD_TYPE=Debug
 
     - name: Linux - Clang 3.9 - Release
-      arch: amd64
       os: linux
       compiler: clang
       addons:
@@ -249,7 +233,6 @@ matrix:
 
 ### Clang 4
     - name: Linux - Clang 4 - Debug
-      arch: amd64
       os: linux
       compiler: clang
       addons:
@@ -265,7 +248,6 @@ matrix:
         - BUILD_TYPE=Debug
 
     - name: Linux - Clang 4 - Release
-      arch: amd64
       os: linux
       compiler: clang
       addons:
@@ -282,7 +264,6 @@ matrix:
 
 ### Clang 5
     - name: Linux - Clang 5 - Debug
-      arch: amd64
       os: linux
       compiler: clang
       addons:
@@ -298,7 +279,6 @@ matrix:
         - BUILD_TYPE=Debug
 
     - name: Linux - Clang 5 - Release
-      arch: amd64
       os: linux
       compiler: clang
       addons:
@@ -315,7 +295,6 @@ matrix:
 
 ### Clang 6
     - name: Linux - Clang 6 - Debug
-      arch: amd64
       os: linux
       compiler: clang
       addons:
@@ -331,7 +310,6 @@ matrix:
         - BUILD_TYPE=Debug
 
     - name: Linux - Clang 6 - Release
-      arch: amd64
       os: linux
       compiler: clang
       addons:
@@ -348,7 +326,6 @@ matrix:
 
 ### Clang 7
     - name: Linux - Clang 7 - Debug
-      arch: amd64
       os: linux
       compiler: clang
       addons:
@@ -364,7 +341,6 @@ matrix:
         - BUILD_TYPE=Debug
 
     - name: Linux - Clang 7 - Release
-      arch: amd64
       os: linux
       compiler: clang
       addons:
@@ -381,7 +357,6 @@ matrix:
 
 ### Clang 8
     - name: Linux - Clang 8 - Debug
-      arch: amd64
       os: linux
       compiler: clang
       addons:
@@ -397,7 +372,6 @@ matrix:
         - BUILD_TYPE=Debug
 
     - name: Linux - Clang 8 - Release
-      arch: amd64
       os: linux
       compiler: clang
       addons:
@@ -414,7 +388,6 @@ matrix:
 
 ### Clang 9
     - name: Linux - Clang 9 - Debug
-      arch: amd64
       os: linux
       compiler: clang
       addons:
@@ -430,7 +403,6 @@ matrix:
         - BUILD_TYPE=Debug
 
     - name: Linux - Clang 9 - Release
-      arch: amd64
       os: linux
       compiler: clang
       addons:
@@ -447,7 +419,6 @@ matrix:
 
 ### Clang 10
     - name: Linux - Clang 10 - Debug
-      arch: amd64
       os: linux
       compiler: clang
       addons:
@@ -463,7 +434,6 @@ matrix:
         - BUILD_TYPE=Debug
 
     - name: Linux - Clang 10 - Release
-      arch: amd64
       os: linux
       compiler: clang
       addons:
@@ -480,16 +450,92 @@ matrix:
 
 # OSX
 ## Xcode
+### Xcode 8.3
+    - name: OSX - Xcode 8.3 - Debug
+      os: osx
+      osx_image: xcode8.3
+      env:
+        - BUILD_TYPE=Debug
+
+    - name: OSX - Xcode 8.3 - Release
+      os: osx
+      osx_image: xcode8.3
+      env:
+        - BUILD_TYPE=Release
+
+### Xcode 9
+    - name: OSX - Xcode 9 - Debug
+      os: osx
+      osx_image: xcode9
+      env:
+        - BUILD_TYPE=Debug
+
+    - name: OSX - Xcode 9 - Release
+      os: osx
+      osx_image: xcode9
+      env:
+        - BUILD_TYPE=Release
+
+### Xcode 9.1
+    - name: OSX - Xcode 9.1 - Debug
+      os: osx
+      osx_image: xcode9.1
+      env:
+        - BUILD_TYPE=Debug
+
+    - name: OSX - Xcode 9.1 - Release
+      os: osx
+      osx_image: xcode9.1
+      env:
+        - BUILD_TYPE=Release
+
+### Xcode 9.2
+    - name: OSX - Xcode 9.2 - Debug
+      os: osx
+      osx_image: xcode9.2
+      env:
+        - BUILD_TYPE=Debug
+
+    - name: OSX - Xcode 9.2 - Release
+      os: osx
+      osx_image: xcode9.2
+      env:
+        - BUILD_TYPE=Release
+
+### Xcode 9.3
+    - name: OSX - Xcode 9.3 - Debug
+      os: osx
+      osx_image: xcode9.3
+      env:
+        - BUILD_TYPE=Debug
+
+    - name: OSX - Xcode 9.3 - Release
+      os: osx
+      osx_image: xcode9.3
+      env:
+        - BUILD_TYPE=Release
+
+### Xcode 9.4
+    - name: OSX - Xcode 9.4 - Debug
+      os: osx
+      osx_image: xcode9.4
+      env:
+        - BUILD_TYPE=Debug
+
+    - name: OSX - Xcode 9.4 - Release
+      os: osx
+      osx_image: xcode9.4
+      env:
+        - BUILD_TYPE=Release
+
 ### Xcode 10
     - name: OSX - Xcode 10 - Debug
-      arch: amd64
       os: osx
       osx_image: xcode10
       env:
         - BUILD_TYPE=Debug
 
     - name: OSX - Xcode 10 - Release
-      arch: amd64
       os: osx
       osx_image: xcode10
       env:
@@ -497,14 +543,12 @@ matrix:
 
 ### Xcode 10.1
     - name: OSX - Xcode 10.1 - Debug
-      arch: amd64
       os: osx
       osx_image: xcode10.1
       env:
         - BUILD_TYPE=Debug
 
     - name: OSX - Xcode 10.1 - Release
-      arch: amd64
       os: osx
       osx_image: xcode10.1
       env:
@@ -512,14 +556,12 @@ matrix:
 
 ### Xcode 10.2
     - name: OSX - Xcode 10.2 - Debug
-      arch: amd64
       os: osx
       osx_image: xcode10.2
       env:
         - BUILD_TYPE=Debug
 
     - name: OSX - Xcode 10.2 - Release
-      arch: amd64
       os: osx
       osx_image: xcode10.2
       env:
@@ -527,14 +569,12 @@ matrix:
 
 ### Xcode 10.3
     - name: OSX - Xcode 10.3 - Debug
-      arch: amd64
       os: osx
       osx_image: xcode10.3
       env:
         - BUILD_TYPE=Debug
 
     - name: OSX - Xcode 10.3 - Release
-      arch: amd64
       os: osx
       osx_image: xcode10.3
       env:
@@ -542,14 +582,12 @@ matrix:
 
 ### Xcode 11
     - name: OSX - Xcode 11 - Debug
-      arch: amd64
       os: osx
       osx_image: xcode11
       env:
         - BUILD_TYPE=Debug
 
     - name: OSX - Xcode 11 - Release
-      arch: amd64
       os: osx
       osx_image: xcode11
       env:
@@ -557,14 +595,12 @@ matrix:
 
 ### Xcode 11.1
     - name: OSX - Xcode 11.1 - Debug
-      arch: amd64
       os: osx
       osx_image: xcode11.1
       env:
         - BUILD_TYPE=Debug
 
     - name: OSX - Xcode 11.1 - Release
-      arch: amd64
       os: osx
       osx_image: xcode11.1
       env:
@@ -572,14 +608,12 @@ matrix:
 
 ### Xcode 11.2
     - name: OSX - Xcode 11.2 - Debug
-      arch: amd64
       os: osx
       osx_image: xcode11.2
       env:
         - BUILD_TYPE=Debug
 
     - name: OSX - Xcode 11.2 - Release
-      arch: amd64
       os: osx
       osx_image: xcode11.2
       env:
@@ -587,14 +621,12 @@ matrix:
 
 ### Xcode 11.3
     - name: OSX - Xcode 11.3 - Debug
-      arch: amd64
       os: osx
       osx_image: xcode11.3
       env:
         - BUILD_TYPE=Debug
 
     - name: OSX - Xcode 11.3 - Release
-      arch: amd64
       os: osx
       osx_image: xcode11.3
       env:
@@ -602,14 +634,12 @@ matrix:
 
 ### Xcode 11.4
     - name: OSX - Xcode 11.4 - Debug
-      arch: amd64
       os: osx
       osx_image: xcode11.4
       env:
         - BUILD_TYPE=Debug
 
     - name: OSX - Xcode 11.4 - Release
-      arch: amd64
       os: osx
       osx_image: xcode11.4
       env:
@@ -617,14 +647,12 @@ matrix:
 
 ### Xcode 11.5
     - name: OSX - Xcode 11.5 - Debug
-      arch: amd64
       os: osx
       osx_image: xcode11.5
       env:
         - BUILD_TYPE=Debug
 
     - name: OSX - Xcode 11.5 - Release
-      arch: amd64
       os: osx
       osx_image: xcode11.5
       env:
@@ -632,14 +660,12 @@ matrix:
 
 ### Xcode 11.6
     - name: OSX - Xcode 11.6 - Debug
-      arch: amd64
       os: osx
       osx_image: xcode11.6
       env:
         - BUILD_TYPE=Debug
 
     - name: OSX - Xcode 11.6 - Release
-      arch: amd64
       os: osx
       osx_image: xcode11.6
       env:
@@ -647,14 +673,12 @@ matrix:
 
 ### Xcode 12
     - name: OSX - Xcode 12 - Debug
-      arch: amd64
       os: osx
       osx_image: xcode12
       env:
         - BUILD_TYPE=Debug
 
     - name: OSX - Xcode 12 - Release
-      arch: amd64
       os: osx
       osx_image: xcode12
       env:
@@ -669,6 +693,7 @@ install:
   # Build and SFML dependencies
   - |
     if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+      brew update-reset
       brew list git &>/dev/null || brew install git
       brew list cmake &>/dev/null || brew install cmake
       brew list ninja &>/dev/null || brew install ninja
@@ -690,7 +715,7 @@ install:
   - cd cmake-build
   - mkdir $HOME/sfml_install
   - cmake -GNinja -DCMAKE_CONFIGURATION_TYPES=${BUILD_TYPE} -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DCMAKE_INSTALL_PREFIX=$HOME/sfml_install ..
-  - cmake --build . --target install
+  - cmake --build . --config ${BUILD_TYPE} --target install
 
   # Dear ImGui
   - git clone --recurse --depth 1 https://github.com/ocornut/imgui $HOME/imgui_local

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,550 @@
+language: cpp
+
+dist: bionic
+
+git:
+  depth: 1
+  submodules: true
+
+matrix:
+  include:
+# Linux
+## GCC
+### GCC 7
+    - name: Linux - GCC 7 - Debug
+      arch: amd64
+      os: linux
+      compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-7
+      env:
+        - COMPILER=g++-7
+        - BUILD_TYPE=Debug
+
+    - name: Linux - GCC 7 - Release
+      arch: amd64
+      os: linux
+      compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-7
+      env:
+        - COMPILER=g++-7
+        - BUILD_TYPE=Release
+
+### GCC 8
+    - name: Linux - GCC 8 - Debug
+      arch: amd64
+      os: linux
+      compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-8
+      env:
+        - COMPILER=g++-8
+        - BUILD_TYPE=Debug
+
+    - name: Linux - GCC 8 - Release
+      arch: amd64
+      os: linux
+      compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-8
+      env:
+        - COMPILER=g++-8
+        - BUILD_TYPE=Release
+
+### GCC 9
+    - name: Linux - GCC 9 - Debug
+      arch: amd64
+      os: linux
+      compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-9
+      env:
+        - COMPILER=g++-9
+        - BUILD_TYPE=Debug
+
+    - name: Linux - GCC 9 - Release
+      arch: amd64
+      os: linux
+      compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-9
+      env:
+        - COMPILER=g++-9
+        - BUILD_TYPE=Release
+
+### GCC 10
+    - name: Linux - GCC 10 - Debug
+      arch: amd64
+      os: linux
+      compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-10
+      env:
+        - COMPILER=g++-10
+        - BUILD_TYPE=Debug
+
+    - name: Linux - GCC 10 - Release
+      arch: amd64
+      os: linux
+      compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-10
+      env:
+        - COMPILER=g++-10
+        - BUILD_TYPE=Release
+
+## Clang
+### Clang 5
+    - name: Linux - Clang 5 - Debug
+      arch: amd64
+      os: linux
+      compiler: clang
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-bionic-5.0
+          packages:
+            - clang-5.0
+            - g++-7
+      env:
+        - COMPILER=clang++-5.0
+        - BUILD_TYPE=Debug
+
+    - name: Linux - Clang 5 - Release
+      arch: amd64
+      os: linux
+      compiler: clang
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-bionic-5.0
+          packages:
+            - clang-5.0
+            - g++-7
+      env:
+        - COMPILER=clang++-5.0
+        - BUILD_TYPE=Release
+
+### Clang 6
+    - name: Linux - Clang 6 - Debug
+      arch: amd64
+      os: linux
+      compiler: clang
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-bionic-6.0
+          packages:
+            - clang-6.0
+            - g++-7
+      env:
+        - COMPILER=clang++-6.0
+        - BUILD_TYPE=Debug
+
+    - name: Linux - Clang 6 - Release
+      arch: amd64
+      os: linux
+      compiler: clang
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-bionic-6.0
+          packages:
+            - clang-6.0
+            - g++-7
+      env:
+        - COMPILER=clang++-6.0
+        - BUILD_TYPE=Release
+
+### Clang 7
+    - name: Linux - Clang 7 - Debug
+      arch: amd64
+      os: linux
+      compiler: clang
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-bionic-7
+          packages:
+            - clang-7
+            - g++-7
+      env:
+        - COMPILER=clang++-7
+        - BUILD_TYPE=Debug
+
+    - name: Linux - Clang 7 - Release
+      arch: amd64
+      os: linux
+      compiler: clang
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-bionic-7
+          packages:
+            - clang-7
+            - g++-7
+      env:
+        - COMPILER=clang++-7
+        - BUILD_TYPE=Release
+
+### Clang 8
+    - name: Linux - Clang 8 - Debug
+      arch: amd64
+      os: linux
+      compiler: clang
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-bionic-8
+          packages:
+            - clang-8
+            - g++-8
+      env:
+        - COMPILER=clang++-8
+        - BUILD_TYPE=Debug
+
+    - name: Linux - Clang 8 - Release
+      arch: amd64
+      os: linux
+      compiler: clang
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-bionic-8
+          packages:
+            - clang-8
+            - g++-8
+      env:
+        - COMPILER=clang++-8
+        - BUILD_TYPE=Release
+
+### Clang 9
+    - name: Linux - Clang 9 - Debug
+      arch: amd64
+      os: linux
+      compiler: clang
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-bionic-9
+          packages:
+            - clang-9
+            - g++-9
+      env:
+        - COMPILER=clang++-9
+        - BUILD_TYPE=Debug
+
+    - name: Linux - Clang 9 - Release
+      arch: amd64
+      os: linux
+      compiler: clang
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-bionic-9
+          packages:
+            - clang-9
+            - g++-9
+      env:
+        - COMPILER=clang++-9
+        - BUILD_TYPE=Release
+
+### Clang 10
+    - name: Linux - Clang 10 - Debug
+      arch: amd64
+      os: linux
+      compiler: clang
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-bionic-10
+          packages:
+            - clang-10
+            - g++-10
+      env:
+        - COMPILER=clang++-10
+        - BUILD_TYPE=Debug
+
+    - name: Linux - Clang 10 - Release
+      arch: amd64
+      os: linux
+      compiler: clang
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-bionic-10
+          packages:
+            - clang-10
+            - g++-10
+      env:
+        - COMPILER=clang++-10
+        - BUILD_TYPE=Release
+
+# OSX
+## Xcode
+### Xcode 10
+    - name: OSX - Xcode 10 - Debug
+      arch: amd64
+      os: osx
+      osx_image: xcode10
+      env:
+        - BUILD_TYPE=Debug
+
+    - name: OSX - Xcode 10 - Release
+      arch: amd64
+      os: osx
+      osx_image: xcode10
+      env:
+        - BUILD_TYPE=Release
+
+### Xcode 10.1
+    - name: OSX - Xcode 10.1 - Debug
+      arch: amd64
+      os: osx
+      osx_image: xcode10.1
+      env:
+        - BUILD_TYPE=Debug
+
+    - name: OSX - Xcode 10.1 - Release
+      arch: amd64
+      os: osx
+      osx_image: xcode10.1
+      env:
+        - BUILD_TYPE=Release
+
+### Xcode 10.2
+    - name: OSX - Xcode 10.2 - Debug
+      arch: amd64
+      os: osx
+      osx_image: xcode10.2
+      env:
+        - BUILD_TYPE=Debug
+
+    - name: OSX - Xcode 10.2 - Release
+      arch: amd64
+      os: osx
+      osx_image: xcode10.2
+      env:
+        - BUILD_TYPE=Release
+
+### Xcode 10.3
+    - name: OSX - Xcode 10.3 - Debug
+      arch: amd64
+      os: osx
+      osx_image: xcode10.3
+      env:
+        - BUILD_TYPE=Debug
+
+    - name: OSX - Xcode 10.3 - Release
+      arch: amd64
+      os: osx
+      osx_image: xcode10.3
+      env:
+        - BUILD_TYPE=Release
+
+### Xcode 11
+    - name: OSX - Xcode 11 - Debug
+      arch: amd64
+      os: osx
+      osx_image: xcode11
+      env:
+        - BUILD_TYPE=Debug
+
+    - name: OSX - Xcode 11 - Release
+      arch: amd64
+      os: osx
+      osx_image: xcode11
+      env:
+        - BUILD_TYPE=Release
+
+### Xcode 11.1
+    - name: OSX - Xcode 11.1 - Debug
+      arch: amd64
+      os: osx
+      osx_image: xcode11.1
+      env:
+        - BUILD_TYPE=Debug
+
+    - name: OSX - Xcode 11.1 - Release
+      arch: amd64
+      os: osx
+      osx_image: xcode11.1
+      env:
+        - BUILD_TYPE=Release
+
+### Xcode 11.2
+    - name: OSX - Xcode 11.2 - Debug
+      arch: amd64
+      os: osx
+      osx_image: xcode11.2
+      env:
+        - BUILD_TYPE=Debug
+
+    - name: OSX - Xcode 11.2 - Release
+      arch: amd64
+      os: osx
+      osx_image: xcode11.2
+      env:
+        - BUILD_TYPE=Release
+
+### Xcode 11.3
+    - name: OSX - Xcode 11.3 - Debug
+      arch: amd64
+      os: osx
+      osx_image: xcode11.3
+      env:
+        - BUILD_TYPE=Debug
+
+    - name: OSX - Xcode 11.3 - Release
+      arch: amd64
+      os: osx
+      osx_image: xcode11.3
+      env:
+        - BUILD_TYPE=Release
+
+### Xcode 11.4
+    - name: OSX - Xcode 11.4 - Debug
+      arch: amd64
+      os: osx
+      osx_image: xcode11.4
+      env:
+        - BUILD_TYPE=Debug
+
+    - name: OSX - Xcode 11.4 - Release
+      arch: amd64
+      os: osx
+      osx_image: xcode11.4
+      env:
+        - BUILD_TYPE=Release
+
+### Xcode 11.5
+    - name: OSX - Xcode 11.5 - Debug
+      arch: amd64
+      os: osx
+      osx_image: xcode11.5
+      env:
+        - BUILD_TYPE=Debug
+
+    - name: OSX - Xcode 11.5 - Release
+      arch: amd64
+      os: osx
+      osx_image: xcode11.5
+      env:
+        - BUILD_TYPE=Release
+
+### Xcode 11.6
+    - name: OSX - Xcode 11.6 - Debug
+      arch: amd64
+      os: osx
+      osx_image: xcode11.6
+      env:
+        - BUILD_TYPE=Debug
+
+    - name: OSX - Xcode 11.6 - Release
+      arch: amd64
+      os: osx
+      osx_image: xcode11.6
+      env:
+        - BUILD_TYPE=Release
+
+### Xcode 12
+    - name: OSX - Xcode 12 - Debug
+      arch: amd64
+      os: osx
+      osx_image: xcode12
+      env:
+        - BUILD_TYPE=Debug
+
+    - name: OSX - Xcode 12 - Release
+      arch: amd64
+      os: osx
+      osx_image: xcode12
+      env:
+        - BUILD_TYPE=Release
+
+before_install:
+  # Variables
+  - if [[ "${COMPILER}" != "" ]]; then export CXX=${COMPILER}; fi
+  - if [[ "${BUILD_TYPE}" == "" ]]; then export BUILD_TYPE=Debug; fi
+
+install:
+  # Build and SFML dependencies
+  - |
+    if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+      brew list git &>/dev/null || brew install git
+      brew list cmake &>/dev/null || brew install cmake
+      brew list ninja &>/dev/null || brew install ninja
+    else
+      sudo apt-get -y install git cmake ninja-build
+      sudo apt-get -y install libsfml-dev libudev-dev libopenal-dev libvorbis-dev libflac-dev libxrandr-dev freeglut3-dev libjpeg-dev libfreetype6-dev libxrandr-dev libglew-dev libsndfile1-dev libopenal-dev libfreetype6-dev
+    fi
+
+  # Info
+  - uname -a
+  - cmake --version
+  - ninja --version
+  - ${CXX} --version
+
+  # SFML
+  - git clone --recurse --depth 1 https://github.com/SFML/SFML $HOME/sfml_local
+  - cd $HOME/sfml_local
+  - mkdir cmake-build
+  - cd cmake-build
+  - mkdir $HOME/sfml_install
+  - cmake -GNinja -DCMAKE_CONFIGURATION_TYPES=${BUILD_TYPE} -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DCMAKE_INSTALL_PREFIX=$HOME/sfml_install ..
+  - cmake --build . --target install
+
+  # Dear ImGui
+  - git clone --recurse --depth 1 https://github.com/ocornut/imgui $HOME/imgui_local
+
+script:
+  - cd $TRAVIS_BUILD_DIR
+  - mkdir cmake-build
+  - cd cmake-build
+  - cmake -GNinja -DCMAKE_CONFIGURATION_TYPES=${BUILD_TYPE} -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DCMAKE_PREFIX_PATH=$HOME/sfml_install -DSFML_DIR=$HOME/sfml_install -DIMGUI_DIR=$HOME/imgui_local -DBUILD_SHARED_LIBS=ON ..
+  - cmake --build . --config ${BUILD_TYPE}

--- a/.travis.yml
+++ b/.travis.yml
@@ -214,6 +214,72 @@ matrix:
         - BUILD_TYPE=Release
 
 ## Clang
+### Clang 3.9
+    - name: Linux - Clang 3.9 - Debug
+      arch: amd64
+      os: linux
+      compiler: clang
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-bionic-3.9
+          packages:
+            - clang-3.9
+            - g++-6
+      env:
+        - COMPILER=clang++-3.9
+        - BUILD_TYPE=Debug
+
+    - name: Linux - Clang 3.9 - Release
+      arch: amd64
+      os: linux
+      compiler: clang
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-bionic-3.9
+          packages:
+            - clang-3.9
+            - g++-6
+      env:
+        - COMPILER=clang++-3.9
+        - BUILD_TYPE=Release
+
+### Clang 4
+    - name: Linux - Clang 4 - Debug
+      arch: amd64
+      os: linux
+      compiler: clang
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-bionic-4.0
+          packages:
+            - clang-4.0
+            - g++-6
+      env:
+        - COMPILER=clang++-4.0
+        - BUILD_TYPE=Debug
+
+    - name: Linux - Clang 4 - Release
+      arch: amd64
+      os: linux
+      compiler: clang
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-bionic-4.0
+          packages:
+            - clang-4.0
+            - g++-6
+      env:
+        - COMPILER=clang++-4.0
+        - BUILD_TYPE=Release
+
 ### Clang 5
     - name: Linux - Clang 5 - Debug
       arch: amd64


### PR DESCRIPTION
Fixing #84, here is a pretty complete CI config for Windows / Linux / macOS with Visual Studio / Xcode / gcc / clang in most versions, feel free to comment or remove any system in the configs that you are not interested in. 

In every configurations the main steps are:
- Install build tools (cmake, ninja, ccache, gcc, clang, ...) depending on the config
- Install SFML dependencies (Linux only, SFML repository embed all dependencies for Windows and macOS)
- Download, configure, build, install SFML
- Download Dear ImGui
- Configure imgui-sfml
- Build imgui-sfml

Except for Visual Studio on AppVeyor, every build uses ccache and a cache system depending on the provider to keep the cache between builds, it is especially usefull for SFML as most of the source files doesn't change most of the time.

Yeah I wanted the Github Actions build config to work on Windows, Linux and macOS at the same time so I made the scripts in cmake to havoid aving to do it in bash and then again in Powershell.