### PR TITLE
enable ImGui_SFML to be built when SFML was being added as subdirectory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,6 @@ if(POLICY CMP0077)
 endif()
 
 option(IMGUI_SFML_BUILD_EXAMPLES "Build ImGui_SFML examples" OFF)
-option(IMGUI_SFML_FIND_SFML "Use find_package to find SFML" ON)
 option(IMGUI_SFML_IMGUI_DEMO "Build imgui_demo.cpp" OFF)
 
 # If you want to use your own user config when compiling ImGui, please set the following variables
@@ -37,7 +36,7 @@ set(IMGUI_SFML_CONFIG_INSTALL_DIR "" CACHE PATH "Path where user's config header
 # For FindImGui.cmake
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
 
-if (IMGUI_SFML_FIND_SFML)
+if (NOT TARGET sfml-graphics OR NOT TARGET sfml-system OR NOT TARGET sfml-window)
 	if (NOT BUILD_SHARED_LIBS)
 		set(SFML_STATIC_LIBRARIES ON)
 	endif()

--- a/conanfile.py
+++ b/conanfile.py
@@ -90,7 +90,6 @@ class ImguiSfmlConan(ConanFile):
         cmake.definitions['IMGUI_DIR'] = os.path.join(self.source_folder, self._imgui_dir)
         cmake.definitions['SFML_DIR'] = os.path.join(self.deps_cpp_info['sfml'].lib_paths[0], 'cmake', 'SFML')
         cmake.definitions['IMGUI_SFML_BUILD_EXAMPLES'] = 'OFF'
-        cmake.definitions['IMGUI_SFML_FIND_SFML'] = 'ON'
         if self.options.imconfig_install_folder:
             cmake.definitions['IMGUI_SFML_CONFIG_INSTALL_DIR'] = self.options.imconfig_install_folder
         if self.options.imconfig:


### PR DESCRIPTION
right now, when including SFML and ImGui_SFML as dependencies and building them from source
like following
```
add_subdirectory(third_party/SFML)
SET(IMGUI_DIR "...")
add_subdirectory(third_party/imgui-sfml)

target_link_libraries(main sfml-system sfml-window sfml-graphics ImGui-SFML::ImGui-SFML)
```

cmake will fail to call find_package(SFML), to fix that we
should not call `find_package` when there's already sfml-graphics etc
targets exist (this is the situation where we include SFML as
subdirectory instead of using system SFML).