### PR TITLE
Fixed inclusion of imgui_tables.cpp source file

### DIFF
--- a/cmake/FindImGui.cmake
+++ b/cmake/FindImGui.cmake
@@ -26,7 +26,6 @@ endif()
 set(IMGUI_SOURCES
   ${IMGUI_INCLUDE_DIR}/imgui.cpp
   ${IMGUI_INCLUDE_DIR}/imgui_draw.cpp
-  ${IMGUI_INCLUDE_DIR}/imgui_tables.cpp
   ${IMGUI_INCLUDE_DIR}/imgui_widgets.cpp
   ${IMGUI_INCLUDE_DIR}/misc/cpp/imgui_stdlib.cpp
 )
@@ -48,6 +47,10 @@ if(NOT IMGUI_VERSION)
 endif()
 # Transform '#define IMGUI_VERSION "X.Y"' into 'X.Y'
 string(REGEX REPLACE ".*\"(.*)\".*" "\\1" IMGUI_VERSION "${IMGUI_VERSION}")
+
+if(${IMGUI_VERSION} VERSION_GREATER_EQUAL "1.80")
+  list(APPEND IMGUI_SOURCES ${IMGUI_INCLUDE_DIR}/imgui_tables.cpp)
+endif()
 
 # Check required version
 if(${IMGUI_VERSION} VERSION_LESS ${ImGui_FIND_VERSION})


### PR DESCRIPTION
Hello! Thank you for this amazing library!

I added a fix to the inclusion of the source file `imgui_tables.cpp` inside the `cmake/FindImGui.cmake` file. As you may know, this source file is part of the new release of Dear ImGui v1.80, but it was missing in prior releases.

For that reason, ImGui-SFML was refusing to build for versions of Dear ImGui lower than v1.80, because that specific file was missing. I just confitionally included the file in the `IMGUI_SOURCES`, depending on the version of Dear ImGui.

If you think the condition should be different (maybe a specific commit or something else), feel free to modify whatever is necessary.