### PR TITLE
Add version to CMake install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,3 +150,14 @@ install(EXPORT ImGui-SFML
   NAMESPACE ImGui-SFML::
   FILE ImGui-SFMLConfig.cmake
 )
+
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file(
+  ImGui-SFMLConfigVersion.cmake
+  VERSION ${CMAKE_PROJECT_VERSION}
+  COMPATIBILITY SameMajorVersion
+)
+install(
+  FILES "${CMAKE_CURRENT_BINARY_DIR}/ImGui-SFMLConfigVersion.cmake"
+  DESTINATION lib/cmake/ImGui-SFML
+)

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ If you set `CMAKE_INSTALL_PREFIX` during configuration, you can install ImGui-SF
 
 Integrating into your project is simple.
 ```cmake
-find_package(ImGui-SFML REQUIRED)
+find_package(ImGui-SFML 2 REQUIRED)
 target_link_libraries(my_target PRIVATE ImGui-SFML::ImGui-SFML)
 ```
 


### PR DESCRIPTION
This PR allows users to provide a version to find_package, with a same major version compatibility.
Even though I changed the readme to reflect this change, providing a version is optional, so it doesn't break anything for current users 😉