### PR TITLE
Support #define ImDrawIdx unsigned int in renderer via imconfig.h

### DIFF
--- a/imgui-SFML.cpp
+++ b/imgui-SFML.cpp
@@ -842,7 +842,8 @@ void RenderDrawLists(ImDrawData* draw_data) {
                     // Bind texture, Draw
                     GLuint textureHandle = convertImTextureIDToGLTextureHandle(pcmd->TextureId);
                     glBindTexture(GL_TEXTURE_2D, textureHandle);
-                    glDrawElements(GL_TRIANGLES, (GLsizei)pcmd->ElemCount, GL_UNSIGNED_SHORT,
+                    glDrawElements(GL_TRIANGLES, (GLsizei)pcmd->ElemCount,
+                                   sizeof(ImDrawIdx) == 2 ? GL_UNSIGNED_SHORT : GL_UNSIGNED_INT,
                                    idx_buffer);
                 }
             }


### PR DESCRIPTION
In `imconfig.h` we can enable support for more than 64k of vertices in the draw list be enabling the hash define see: https://github.com/ocornut/imgui/blob/f99fe72c42bd5d578c2443409192b139b1c6623d/imconfig.h#L96

This can be supported in this framework by making sure GL knows the correct size of the index buffer when we go to render.