### PR TITLE
Image drawing sf::Sprite respects transformation

### DIFF
--- a/imgui-SFML.cpp
+++ b/imgui-SFML.cpp
@@ -701,9 +701,8 @@ void Image(const sf::Sprite& sprite, const sf::Vector2f& size, const sf::Transfo
 {
     const sf::IntRect& textureRect = sprite.getTextureRect();
 
-    // sprite without or empty texture cannot be drawn
+    // sprite without texture on empty frame cannot be drawn
     if (!sprite.getTexture() ||
-        textureRect.width <= 0 || textureRect.height <= 0 ||
         size.x <= 0 || size.y <= 0) {
         return;
     }

--- a/imgui-SFML.cpp
+++ b/imgui-SFML.cpp
@@ -732,7 +732,7 @@ void Image(const sf::Sprite& sprite, const sf::Vector2f& size, const sf::Transfo
 
     sf::Transform finalTransform = transform * sprite.getTransform();
 	sf::FloatRect spriteRect = sprite.getLocalBounds();
-	const sf::FloatRect bounding = transform.transformRect(spriteRect);
+	const sf::FloatRect bounding = finalTransform.transformRect(spriteRect);
 
     // applies the transformations which are expected as a item of the parent window
     const float offset = static_cast<float>(borderColor.a > 0);

--- a/imgui-SFML.cpp
+++ b/imgui-SFML.cpp
@@ -734,8 +734,9 @@ void Image(const sf::Sprite& sprite, const sf::Vector2f& size, const sf::Transfo
 	const sf::FloatRect bounding = transform.transformRect(spriteRect);
 
     // applies the transformations which are expected as a item of the parent window
+    const float offset = static_cast<float>(borderColor.a > 0);
     sf::Transform itemTransform;
-    itemTransform.translate(itemBB.Min.x, itemBB.Min.y).
+    itemTransform.translate(itemBB.Min.x + offset, itemBB.Min.y + offset).
         scale(size.x / bounding.width, size.y / bounding.height).
         translate(-bounding.getPosition());
     finalTransform = itemTransform * finalTransform;

--- a/imgui-SFML.cpp
+++ b/imgui-SFML.cpp
@@ -726,7 +726,7 @@ void Image(const sf::Sprite& sprite, const sf::Vector2f& size, const sf::Transfo
     // prepare uv coordinates
     const sf::IntRect& textureRect = sprite.getTextureRect();
     const sf::Vector2f textureSize = static_cast<sf::Vector2f>(sprite.getTexture()->getSize());
-    // would result in a division by zero
+    // would lead to a division by zero
     if (textureSize.x == 0 || textureSize.y == 0) {
         return;
     }
@@ -737,6 +737,10 @@ void Image(const sf::Sprite& sprite, const sf::Vector2f& size, const sf::Transfo
     sf::Transform finalTransform = transform * sprite.getTransform();
 	const sf::FloatRect spriteRect = sprite.getLocalBounds();
 	const sf::FloatRect bounding = finalTransform.transformRect(spriteRect);
+    // would lead to a division by zero
+    if (bounding.width == 0 || bounding.height == 0) {
+        return;
+    }
 
     // applies the transformations which are expected as a item of the parent window
     const float offset = static_cast<float>(borderColor.a > 0);

--- a/imgui-SFML.cpp
+++ b/imgui-SFML.cpp
@@ -706,7 +706,7 @@ void Image(const sf::Sprite& sprite, const sf::Vector2f& size, const sf::Transfo
     }
 
     // \begin: emulate behaviour of ImGui::Image
-    ImGuiWindow* window = GetCurrentWindow();
+    ImGuiWindow* window = ImGui::GetCurrentWindow();
     if (window->SkipItems)
         return;
 

--- a/imgui-SFML.cpp
+++ b/imgui-SFML.cpp
@@ -729,8 +729,8 @@ void Image(const sf::Sprite& sprite, const sf::Vector2f& size, const sf::Transfo
     // would result in a division by zero
     if (textureSize.x == 0 || textureSize.y == 0)
         return;
-    ImVec2 uv0(textureRect.left / textureSize.x, textureRect.top / textureSize.y);
-    ImVec2 uv1((textureRect.left + textureRect.width) / textureSize.x,
+    const ImVec2 uv0(textureRect.left / textureSize.x, textureRect.top / textureSize.y);
+    const ImVec2 uv1((textureRect.left + textureRect.width) / textureSize.x,
                (textureRect.top + textureRect.height) / textureSize.y);
 
     sf::Transform finalTransform = transform * sprite.getTransform();

--- a/imgui-SFML.cpp
+++ b/imgui-SFML.cpp
@@ -750,10 +750,6 @@ void Image(const sf::Sprite& sprite, const sf::Vector2f& size, const sf::Transfo
         spriteRect.height -= 2;
     }
 
-	ItemSize(itemBB);
-    if (!ItemAdd(itemBB, 0))
-        return;
-
     ImVec2 pos[4];
     toImVec2Quad(spriteRect, finalTransform, pos);
 

--- a/imgui-SFML.cpp
+++ b/imgui-SFML.cpp
@@ -705,7 +705,7 @@ void Image(const sf::Sprite& sprite, const sf::Vector2f& size, const sf::Transfo
         return;
     }
 
-    // simply taken form ImGui::Image
+    // \begin: emulate behaviour of ImGui::Image
     ImGuiWindow* window = GetCurrentWindow();
     if (window->SkipItems)
         return;
@@ -721,6 +721,7 @@ void Image(const sf::Sprite& sprite, const sf::Vector2f& size, const sf::Transfo
     ImGui::ItemSize(itemBB);
     if (!ImGui::ItemAdd(itemBB, 0))
         return;
+    // \end: emulate behaviour of ImGui::Image
 
     // prepare uv coordinates
     const sf::IntRect& textureRect = sprite.getTextureRect();

--- a/imgui-SFML.cpp
+++ b/imgui-SFML.cpp
@@ -700,35 +700,36 @@ void Image(const sf::Sprite& sprite, const sf::Vector2f& size, const sf::Transfo
     const sf::Color& tintColor, const sf::Color& borderColor)
 {
     // sprite without texture or item with dimensions of zero cannot be drawn
-    if (!sprite.getTexture() ||
-        size.x <= 0 || size.y <= 0) {
+    if (!sprite.getTexture() || size.x <= 0 || size.y <= 0) {
         return;
     }
 
     // \begin: emulate behaviour of ImGui::Image
     ImGuiWindow* window = ImGui::GetCurrentWindow();
-    if (window->SkipItems)
+    if (window->SkipItems) {
         return;
+    }
 
     ImRect itemBB(window->DC.CursorPos.x, window->DC.CursorPos.y,
         window->DC.CursorPos.x + size.x, window->DC.CursorPos.y + size.y);
-    if (borderColor.a > 0)
-    {
+    if (borderColor.a > 0) {
         itemBB.Max.x += 2;
         itemBB.Max.y += 2;
     }
 
     ImGui::ItemSize(itemBB);
-    if (!ImGui::ItemAdd(itemBB, 0))
+    if (!ImGui::ItemAdd(itemBB, 0)) {
         return;
+    }
     // \end: emulate behaviour of ImGui::Image
 
     // prepare uv coordinates
     const sf::IntRect& textureRect = sprite.getTextureRect();
     const sf::Vector2f textureSize = static_cast<sf::Vector2f>(sprite.getTexture()->getSize());
     // would result in a division by zero
-    if (textureSize.x == 0 || textureSize.y == 0)
+    if (textureSize.x == 0 || textureSize.y == 0) {
         return;
+    }
     const ImVec2 uv0(textureRect.left / textureSize.x, textureRect.top / textureSize.y);
     const ImVec2 uv1((textureRect.left + textureRect.width) / textureSize.x,
                (textureRect.top + textureRect.height) / textureSize.y);
@@ -745,15 +746,13 @@ void Image(const sf::Sprite& sprite, const sf::Vector2f& size, const sf::Transfo
         translate(-bounding.getPosition());
     finalTransform = itemTransform * finalTransform;
 
-    if (borderColor.a > 0)
-    {
+    if (borderColor.a > 0) {
         window->DrawList->AddRect(itemBB.Min, itemBB.Max, toImColor(borderColor), 0.f);
     }
 
 	ImVec2 pos[4];
     toImVec2Quad(spriteRect, finalTransform, pos);
-
-    ImTextureID textureID = convertGLTextureHandleToImTextureID(sprite.getTexture()->getNativeHandle());
+    const ImTextureID textureID = convertGLTextureHandleToImTextureID(sprite.getTexture()->getNativeHandle());
     window->DrawList->AddImageQuad(textureID, pos[0], pos[1], pos[2], pos[3],
         uv0, ImVec2(uv1.x, uv0.y), uv1, ImVec2(uv0.x, uv1.y), toImColor(tintColor));
 }

--- a/imgui-SFML.cpp
+++ b/imgui-SFML.cpp
@@ -699,7 +699,7 @@ void Image(const sf::Sprite& sprite, const sf::Vector2f& size, const sf::Color& 
 void Image(const sf::Sprite& sprite, const sf::Vector2f& size, const sf::Transform& transform,
     const sf::Color& tintColor, const sf::Color& borderColor)
 {
-    // sprite without texture on empty frame cannot be drawn
+    // sprite without texture or item with dimensions of zero cannot be drawn
     if (!sprite.getTexture() ||
         size.x <= 0 || size.y <= 0) {
         return;

--- a/imgui-SFML.cpp
+++ b/imgui-SFML.cpp
@@ -718,8 +718,8 @@ void Image(const sf::Sprite& sprite, const sf::Vector2f& size, const sf::Transfo
         itemBB.Max.y += 2;
     }
 
-    ItemSize(itemBB);
-    if (!ItemAdd(itemBB, 0))
+    ImGui::ItemSize(itemBB);
+    if (!ImGui::ItemAdd(itemBB, 0))
         return;
 
     // prepare uv coordinates

--- a/imgui-SFML.cpp
+++ b/imgui-SFML.cpp
@@ -696,11 +696,9 @@ void Image(const sf::Sprite& sprite, const sf::Vector2f& size, const sf::Color& 
 	Image(sprite, size, sf::Transform::Identity, tintColor, borderColor);
 }
 
-void Image(const sf::Sprite& sprite, const sf::Vector2f& size, const sf::Transform& additionalTransform,
+void Image(const sf::Sprite& sprite, const sf::Vector2f& size, const sf::Transform& transform,
     const sf::Color& tintColor, const sf::Color& borderColor)
 {
-    const sf::IntRect& textureRect = sprite.getTextureRect();
-
     // sprite without texture on empty frame cannot be drawn
     if (!sprite.getTexture() ||
         size.x <= 0 || size.y <= 0) {
@@ -730,7 +728,7 @@ void Image(const sf::Sprite& sprite, const sf::Vector2f& size, const sf::Transfo
     ImVec2 uv1((textureRect.left + textureRect.width) / textureSize.x,
                (textureRect.top + textureRect.height) / textureSize.y);
 
-    sf::Transform transform = additionalTransform * sprite.getTransform();
+    sf::Transform finalTransform = transform * sprite.getTransform();
 	sf::FloatRect spriteRect = sprite.getLocalBounds();
 	const sf::FloatRect bounding = transform.transformRect(spriteRect);
 
@@ -739,7 +737,7 @@ void Image(const sf::Sprite& sprite, const sf::Vector2f& size, const sf::Transfo
     childTransform.translate(itemBB.Min.x, itemBB.Min.y).
         scale(size.x / bounding.width, size.y / bounding.height).
         translate(-bounding.getPosition());
-    transform = childTransform * transform;
+    finalTransform = childTransform * finalTransform;
     
 
     if (borderColor.a > 0)
@@ -755,12 +753,12 @@ void Image(const sf::Sprite& sprite, const sf::Vector2f& size, const sf::Transfo
         return;
 
     ImVec2 pos[4];
-    toImVec2Quad(spriteRect, transform, pos);
+    toImVec2Quad(spriteRect, finalTransform, pos);
 
     if (borderColor.a > 0)
     {
         ImVec2 borderPos[4];
-        toImVec2Quad(sprite.getLocalBounds(), transform, borderPos);
+        toImVec2Quad(sprite.getLocalBounds(), finalTransform, borderPos);
         window->DrawList->AddQuad(borderPos[0], borderPos[1], borderPos[2], borderPos[3], toImColor(borderColor), 0.f);
     }
 

--- a/imgui-SFML.cpp
+++ b/imgui-SFML.cpp
@@ -726,12 +726,15 @@ void Image(const sf::Sprite& sprite, const sf::Vector2f& size, const sf::Transfo
     // prepare uv coordinates
     const sf::IntRect& textureRect = sprite.getTextureRect();
     const sf::Vector2f textureSize = static_cast<sf::Vector2f>(sprite.getTexture()->getSize());
+    // would result in a division by zero
+    if (textureSize.x == 0 || textureSize.y == 0)
+        return;
     ImVec2 uv0(textureRect.left / textureSize.x, textureRect.top / textureSize.y);
     ImVec2 uv1((textureRect.left + textureRect.width) / textureSize.x,
                (textureRect.top + textureRect.height) / textureSize.y);
 
     sf::Transform finalTransform = transform * sprite.getTransform();
-	sf::FloatRect spriteRect = sprite.getLocalBounds();
+	const sf::FloatRect spriteRect = sprite.getLocalBounds();
 	const sf::FloatRect bounding = finalTransform.transformRect(spriteRect);
 
     // applies the transformations which are expected as a item of the parent window

--- a/imgui-SFML.cpp
+++ b/imgui-SFML.cpp
@@ -740,25 +740,14 @@ void Image(const sf::Sprite& sprite, const sf::Vector2f& size, const sf::Transfo
         scale(size.x / bounding.width, size.y / bounding.height).
         translate(-bounding.getPosition());
     finalTransform = itemTransform * finalTransform;
-    
 
     if (borderColor.a > 0)
     {
-        spriteRect.left += 1;
-        spriteRect.top += 1;
-        spriteRect.width -= 2;
-        spriteRect.height -= 2;
+        window->DrawList->AddRect(itemBB.Min, itemBB.Max, toImColor(borderColor), 0.f);
     }
 
-    ImVec2 pos[4];
+	ImVec2 pos[4];
     toImVec2Quad(spriteRect, finalTransform, pos);
-
-    if (borderColor.a > 0)
-    {
-        ImVec2 borderPos[4];
-        toImVec2Quad(sprite.getLocalBounds(), finalTransform, borderPos);
-        window->DrawList->AddQuad(borderPos[0], borderPos[1], borderPos[2], borderPos[3], toImColor(borderColor), 0.f);
-    }
 
     ImTextureID textureID = convertGLTextureHandleToImTextureID(sprite.getTexture()->getNativeHandle());
     window->DrawList->AddImageQuad(textureID, pos[0], pos[1], pos[2], pos[3],

--- a/imgui-SFML.cpp
+++ b/imgui-SFML.cpp
@@ -723,6 +723,7 @@ void Image(const sf::Sprite& sprite, const sf::Vector2f& size, const sf::Transfo
         return;
 
     // prepare uv coordinates
+    const sf::IntRect& textureRect = sprite.getTextureRect();
     const sf::Vector2f textureSize = static_cast<sf::Vector2f>(sprite.getTexture()->getSize());
     ImVec2 uv0(textureRect.left / textureSize.x, textureRect.top / textureSize.y);
     ImVec2 uv1((textureRect.left + textureRect.width) / textureSize.x,
@@ -732,12 +733,12 @@ void Image(const sf::Sprite& sprite, const sf::Vector2f& size, const sf::Transfo
 	sf::FloatRect spriteRect = sprite.getLocalBounds();
 	const sf::FloatRect bounding = transform.transformRect(spriteRect);
 
-    // applies the transformations which are expected as a child of the parent window
-    sf::Transform childTransform;
-    childTransform.translate(itemBB.Min.x, itemBB.Min.y).
+    // applies the transformations which are expected as a item of the parent window
+    sf::Transform itemTransform;
+    itemTransform.translate(itemBB.Min.x, itemBB.Min.y).
         scale(size.x / bounding.width, size.y / bounding.height).
         translate(-bounding.getPosition());
-    finalTransform = childTransform * finalTransform;
+    finalTransform = itemTransform * finalTransform;
     
 
     if (borderColor.a > 0)

--- a/imgui-SFML.h
+++ b/imgui-SFML.h
@@ -88,7 +88,11 @@ IMGUI_SFML_API void Image(const sf::RenderTexture& texture, const sf::Vector2f& 
 // Image overloads for sf::Sprite
 IMGUI_SFML_API void Image(const sf::Sprite& sprite, const sf::Color& tintColor = sf::Color::White,
                           const sf::Color& borderColor = sf::Color::Transparent);
-IMGUI_SFML_API void Image(const sf::Sprite& sprite, const sf::Transform& transform,
+IMGUI_SFML_API void Image(const sf::Sprite& sprite, const sf::Vector2f& size,
+                          const sf::Color& tintColor = sf::Color::White,
+                          const sf::Color& borderColor = sf::Color::Transparent);
+IMGUI_SFML_API void Image(const sf::Sprite& sprite, const sf::Vector2f& size,
+                          const sf::Transform& transform,
                           const sf::Color& tintColor = sf::Color::White,
                           const sf::Color& borderColor = sf::Color::Transparent);
 

--- a/imgui-SFML.h
+++ b/imgui-SFML.h
@@ -22,6 +22,7 @@ class RenderTexture;
 class RenderWindow;
 class Sprite;
 class Texture;
+class Transform;
 class Window;
 }
 
@@ -87,7 +88,7 @@ IMGUI_SFML_API void Image(const sf::RenderTexture& texture, const sf::Vector2f& 
 // Image overloads for sf::Sprite
 IMGUI_SFML_API void Image(const sf::Sprite& sprite, const sf::Color& tintColor = sf::Color::White,
                           const sf::Color& borderColor = sf::Color::Transparent);
-IMGUI_SFML_API void Image(const sf::Sprite& sprite, const sf::Vector2f& size,
+IMGUI_SFML_API void Image(const sf::Sprite& sprite, const sf::Transform& transform,
                           const sf::Color& tintColor = sf::Color::White,
                           const sf::Color& borderColor = sf::Color::Transparent);
 


### PR DESCRIPTION
A ``sf::Sprite`` drawn via Image function doesn't respect the transformaiton. That's what I wanted to fix.
This pull request is rather WIP, but this way its easier to talk about improvements and actual behaviour.

The sprite transformation works (proof below) but I had to apply some changes to the interface. This is not a big deal, because it should be easy to simply add my function  and call it from the previous two overloads, thus no breaking change necessary. But here is my second struggle. The positioning and size behaviour of the ``sf::RenderTexture``, ``sf::Texture`` and ``sf::Sprite`` now seem to differ quite a bit. I wasn't able to determine how a ``size`` param should change the appearance of such a sprite, as a sprite itself has a complete transformation. I decided to get rid of that overload and instead add a ``sf::Transform`` param, because this is much more flexible than the provided interface of a ``sf::Sprite``. With a ``sf::Transform`` its possible to perform transformations in different order; the ``sf::Sprite`` uses a fixed ordering.

Looking forward for any feedback!

![image](https://user-images.githubusercontent.com/761844/147369076-6eb0717f-b6ea-40a8-92e1-be24b1716324.png)
