### PR TITLE
Prevent leaking memory on cursors

### DIFF
--- a/imgui-SFML.cpp
+++ b/imgui-SFML.cpp
@@ -223,7 +223,7 @@ struct WindowContext {
     ~WindowContext() {
         delete fontTexture;
         for (int i = 0; i < ImGuiMouseCursor_COUNT; ++i) {
-            if (mouseCursorLoaded[i]) {
+            if (mouseCursors[i] != nullptr) {
                 delete mouseCursors[i];
             }
         }


### PR DESCRIPTION
Hello, 
It's my first PR to this project, I don't know what is the correct procedure yet :)

During the Init process, bunch of cursors being allocated:
```
// load mouse cursors
loadMouseCursor(ImGuiMouseCursor_Arrow, sf::Cursor::Arrow);
loadMouseCursor(ImGuiMouseCursor_TextInput, sf::Cursor::Text);
loadMouseCursor(ImGuiMouseCursor_ResizeAll, sf::Cursor::SizeAll);
loadMouseCursor(ImGuiMouseCursor_ResizeNS, sf::Cursor::SizeVertical);
loadMouseCursor(ImGuiMouseCursor_ResizeEW, sf::Cursor::SizeHorizontal);
loadMouseCursor(ImGuiMouseCursor_ResizeNESW, sf::Cursor::SizeBottomLeftTopRight);
loadMouseCursor(ImGuiMouseCursor_ResizeNWSE, sf::Cursor::SizeTopLeftBottomRight);
loadMouseCursor(ImGuiMouseCursor_Hand, sf::Cursor::Hand);
```

loadMouseCursor function allocates memory for cursor and marks whether loading the cursor succeed or not:

```
void loadMouseCursor(ImGuiMouseCursor imguiCursorType, sf::Cursor::Type sfmlCursorType) {
     s_currWindowCtx->mouseCursors[imguiCursorType] = new sf::Cursor();
     s_currWindowCtx->mouseCursorLoaded[imguiCursorType] =
     s_currWindowCtx->mouseCursors[imguiCursorType]->loadFromSystem(sfmlCursorType);
}
```

Destructor deletes only cursors marked as 'loaded':
```
     ~WindowContext() {
         delete fontTexture;
         for (int i = 0; i < ImGuiMouseCursor_COUNT; ++i) {
             if (mouseCursorLoaded[i]) {
                 delete mouseCursors[i];
             }
         }
         ImGui::DestroyContext(imContext);
    }
```

However, it's very much possible that the cursor couldn't be loaded and the space for it won't be de-allocated. Which leaks the memory. 

My PR is a proposal of handling the memory leak.