### PR TITLE
Replaced deprecated sf::Keyboard::Return with sf::Keyboard::Enter

### DIFF
--- a/imgui-SFML.cpp
+++ b/imgui-SFML.cpp
@@ -350,7 +350,7 @@ ImGuiKey keycodeToImGuiKey(sf::Keyboard::Key code) {
         return ImGuiKey_Backspace;
     case sf::Keyboard::Space:
         return ImGuiKey_Space;
-    case sf::Keyboard::Return:
+    case sf::Keyboard::Enter:
         return ImGuiKey_Enter;
     case sf::Keyboard::Escape:
         return ImGuiKey_Escape;


### PR DESCRIPTION
Whilst working on a project using the latest snapshot of SFML master branch (where the SFML v3 commits are going) I noticed that the `sf::Keyboard::Return` was no longer marked deprecated but had now been removed which caused `imgui-sfml.cpp` to fail to compile since it still relied on this enum entry. Replaced the entry with the preferred `sf::Keyboard::Enter`