### PR TITLE
Replace sf::Uint8 with std::uint8_t

### DIFF
--- a/imconfig-SFML.h
+++ b/imconfig-SFML.h
@@ -3,6 +3,8 @@
 #include <SFML/Graphics/Color.hpp>
 #include <SFML/System/Vector2.hpp>
 
+#include <cstdint>
+
 #include "imgui-SFML_export.h"
 
 #define IM_VEC2_CLASS_EXTRA           \
@@ -20,6 +22,8 @@
 #define IM_VEC4_CLASS_EXTRA                                                                        \
     ImVec4(const sf::Color& c) : x(c.r / 255.f), y(c.g / 255.f), z(c.b / 255.f), w(c.a / 255.f) {} \
     operator sf::Color() const {                                                                   \
-        return sf::Color(static_cast<sf::Uint8>(x * 255.f), static_cast<sf::Uint8>(y * 255.f),     \
-                         static_cast<sf::Uint8>(z * 255.f), static_cast<sf::Uint8>(w * 255.f));    \
+        return sf::Color(static_cast<std::uint8_t>(x * 255.f),                                     \
+                         static_cast<std::uint8_t>(y * 255.f),                                     \
+                         static_cast<std::uint8_t>(z * 255.f),                                     \
+                         static_cast<std::uint8_t>(w * 255.f));                                    \
     }

--- a/imgui-SFML.cpp
+++ b/imgui-SFML.cpp
@@ -18,6 +18,7 @@
 #include <cassert>
 #include <cmath> // abs
 #include <cstddef> // offsetof, NULL, size_t
+#include <cstdint> // uint8_t
 #include <cstring> // memcpy
 
 #include <algorithm>
@@ -1376,7 +1377,7 @@ void setClipboardText(void* /*userData*/, const char* text) {
 }
 
 const char* getClipboardText(void* /*userData*/) {
-    std::basic_string<sf::Uint8> tmp = sf::Clipboard::getString().toUtf8();
+    std::basic_string<std::uint8_t> tmp = sf::Clipboard::getString().toUtf8();
     s_clipboardText = std::string(tmp.begin(), tmp.end());
     return s_clipboardText.c_str();
 }


### PR DESCRIPTION
Hello !

Just a small update because sfml recently replaced sf::Uint8 with std::uint8_t
https://github.com/SFML/SFML/commit/e2528de20a58d56c13d22fe64fd55d701ba3c714

The CI fails with mingw errors but it is not linked to my change (only submitting an empty CL to trigger the CI leads to the exact same issue).

Thanks a lot for your work !